### PR TITLE
Add Mod Configuration Menu support for Extreme Ragdoll

### DIFF
--- a/ExtremeRagdoll/ER_KnockbackAmplifier.cs
+++ b/ExtremeRagdoll/ER_KnockbackAmplifier.cs
@@ -9,14 +9,20 @@ namespace ExtremeRagdoll
 {
     internal static class ER_Config
     {
-        public static float KnockbackMultiplier = 6.0f; // temporarily crank up for visibility
-        public static float MaxExtraMagnitude   = 2500f;
-        public static bool  DebugLogging        = true;
+        public static float KnockbackMultiplier =>
+            Settings.Instance?.KnockbackMultiplier ?? 6.0f;
+
+        public static float MaxExtraMagnitude =>
+            Settings.Instance?.MaxExtraMagnitude ?? 2500;
+
+        public static bool DebugLogging =>
+            Settings.Instance?.DebugLogging ?? true;
 
         public static float ClampExtra(float magnitude)
         {
             if (magnitude <= 0f) return 0f;
-            return magnitude > MaxExtraMagnitude ? MaxExtraMagnitude : magnitude;
+            float max = MaxExtraMagnitude;
+            return magnitude > max ? max : magnitude;
         }
     }
 

--- a/ExtremeRagdoll/ExtremeRagdoll.csproj
+++ b/ExtremeRagdoll/ExtremeRagdoll.csproj
@@ -82,6 +82,12 @@
     <Reference Include="TaleWorlds.ObjectSystem">
       <HintPath>D:\Spiele\Mount and Blade II Bannerlord\bin\Win64_Shipping_Client\TaleWorlds.ObjectSystem.dll</HintPath>
     </Reference>
+    <Reference Include="MCMv5">
+      <HintPath>D:\Spiele\Mount and Blade II Bannerlord\Modules\MCMv5\bin\Win64_Shipping_Client\MCMv5.dll</HintPath>
+    </Reference>
+    <Reference Include="MCMv5.Abstractions">
+      <HintPath>D:\Spiele\Mount and Blade II Bannerlord\Modules\MCMv5\bin\Win64_Shipping_Client\MCMv5.Abstractions.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ER_KnockbackAmplifier.cs" />
@@ -89,6 +95,7 @@
     <Compile Include="ER_TOR_Adapter.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SubModule.cs" />
+    <Compile Include="Settings.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/ExtremeRagdoll/Settings.cs
+++ b/ExtremeRagdoll/Settings.cs
@@ -1,0 +1,29 @@
+using MCM.Abstractions.Base.Global;
+using MCM.Abstractions.Attributes;
+using MCM.Abstractions.Attributes.v2;
+
+namespace ExtremeRagdoll
+{
+    public sealed class Settings : AttributeGlobalSettings<Settings>
+    {
+        public override string Id => "ExtremeRagdoll.Settings";
+        public override string DisplayName => "Extreme Ragdoll";
+        public override string FolderName => "ExtremeRagdoll";
+        public override string FormatType => "json";
+
+        [SettingPropertyGroup("General")]
+        [SettingPropertyFloatingInteger("Knockback Multiplier", 1f, 10f, "0.0",
+            Order = 0, RequireRestart = false, HintText = "Scales death shove strength.")]
+        public float KnockbackMultiplier { get; set; } = 6.0f;
+
+        [SettingPropertyGroup("General")]
+        [SettingPropertyInteger("Max Extra Magnitude", 0, 5000,
+            Order = 1, RequireRestart = false, HintText = "Hard cap for injected impulse.")]
+        public int MaxExtraMagnitude { get; set; } = 2500;
+
+        [SettingPropertyGroup("General")]
+        [SettingPropertyBool("Debug Logging",
+            Order = 2, RequireRestart = false, HintText = "Print shove lines to rgl_log.")]
+        public bool DebugLogging { get; set; } = true;
+    }
+}

--- a/ExtremeRagdoll/SubModule.cs
+++ b/ExtremeRagdoll/SubModule.cs
@@ -10,6 +10,7 @@ namespace ExtremeRagdoll
         protected override void OnSubModuleLoad()
         {
             new Harmony("extremeragdoll.patch").PatchAll();
+            _ = Settings.Instance;
         }
 
         protected override void OnBeforeInitialModuleScreenSetAsRoot()


### PR DESCRIPTION
## Summary
- add an MCM settings definition so knockback, magnitude cap, and debug logging can be tuned in-game
- load the settings on module start and surface them through the existing configuration helper
- reference the required MCM assemblies in the project

## Testing
- not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68d6277803a08320ba24ac475e4627f1