### PR TITLE
Align MCM integration with v5 requirements

### DIFF
--- a/ExtremeRagdoll/ExtremeRagdoll.csproj
+++ b/ExtremeRagdoll/ExtremeRagdoll.csproj
@@ -84,7 +84,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Bannerlord.MCM" Version="5.10.1" IncludeAssets="compile" PrivateAssets="all" />
+    <PackageReference Include="Bannerlord.MCM" Version="5.10.1" IncludeAssets="compile" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ER_KnockbackAmplifier.cs" />

--- a/ExtremeRagdoll/Settings.cs
+++ b/ExtremeRagdoll/Settings.cs
@@ -4,28 +4,42 @@ using MCM.Abstractions.Attributes.v2;
 
 namespace ExtremeRagdoll
 {
-    // Attribute settings => automatically discovered by MCM
-    public sealed class Settings : AttributeGlobalSettings<Settings>
+    internal sealed class Settings : AttributeGlobalSettings<Settings>
     {
-        // Keep Id stable & unique; matching module Id is fine
         public override string Id => "ExtremeRagdoll_v1";
         public override string DisplayName => "Extreme Ragdoll";
         public override string FolderName => "ExtremeRagdoll";
         public override string FormatType => "json";
 
+        private float _knockbackMultiplier = 6.0f;
+        private int   _maxExtraMagnitude   = 2500;
+        private bool  _debugLogging        = true;
+
         [SettingPropertyGroup("General")]
         [SettingPropertyFloatingInteger("Knockback Multiplier", 1f, 10f, "0.0",
             Order = 0, RequireRestart = false, HintText = "Scales death shove strength.")]
-        public float KnockbackMultiplier { get; set; } = 6.0f;
+        public float KnockbackMultiplier
+        {
+            get => _knockbackMultiplier;
+            set { if (_knockbackMultiplier != value) { _knockbackMultiplier = value; OnPropertyChanged(); } }
+        }
 
         [SettingPropertyGroup("General")]
         [SettingPropertyInteger("Max Extra Magnitude", 0, 5000,
             Order = 1, RequireRestart = false, HintText = "Hard cap for injected impulse.")]
-        public int MaxExtraMagnitude { get; set; } = 2500;
+        public int MaxExtraMagnitude
+        {
+            get => _maxExtraMagnitude;
+            set { if (_maxExtraMagnitude != value) { _maxExtraMagnitude = value; OnPropertyChanged(); } }
+        }
 
         [SettingPropertyGroup("General")]
         [SettingPropertyBool("Debug Logging",
             Order = 2, RequireRestart = false, HintText = "Print shove lines to log.")]
-        public bool DebugLogging { get; set; } = true;
+        public bool DebugLogging
+        {
+            get => _debugLogging;
+            set { if (_debugLogging != value) { _debugLogging = value; OnPropertyChanged(); } }
+        }
     }
 }

--- a/ExtremeRagdoll/SubModule.cs
+++ b/ExtremeRagdoll/SubModule.cs
@@ -1,5 +1,4 @@
 using HarmonyLib;
-using TaleWorlds.Core;
 using TaleWorlds.MountAndBlade;
 
 namespace ExtremeRagdoll
@@ -10,14 +9,12 @@ namespace ExtremeRagdoll
 
         protected override void OnSubModuleLoad()
         {
-            _ = Settings.Instance;
             new Harmony("extremeragdoll.patch").PatchAll();
         }
 
         protected override void OnBeforeInitialModuleScreenSetAsRoot()
         {
-            InformationManager.DisplayMessage(
-                new InformationMessage("[ExtremeRagdoll] MCM settings loaded"));
+            _ = Settings.Instance; // lets MCM pick it up; earliest safe point per docs
             if (_adapted) return;
             try { _adapted = ER_TOR_Adapter.TryEnableShockwaves(); }
             catch { _adapted = false; }


### PR DESCRIPTION
## Summary
- update the Bannerlord.MCM package reference to the compile-only configuration required by the v5 standalone path
- replace the settings implementation with the official Attribute API pattern, including change notifications
- defer settings initialization to OnBeforeInitialModuleScreenSetAsRoot per the safe-touch guidance while keeping existing runtime hooks

## Testing
- not run (per instructions)

------
https://chatgpt.com/codex/tasks/task_e_68d65453ee70832099672941131a04cd