### PR TITLE
Add temporary startup debug messages

### DIFF
--- a/ExtremeRagdoll/SubModule.cs
+++ b/ExtremeRagdoll/SubModule.cs
@@ -15,6 +15,10 @@ namespace ExtremeRagdoll
         protected override void OnBeforeInitialModuleScreenSetAsRoot()
         {
             _ = Settings.Instance; // lets MCM pick it up; earliest safe point per docs
+            TaleWorlds.Core.InformationManager.DisplayMessage(
+                new TaleWorlds.Core.InformationMessage($"[ExtremeRagdoll] Settings discovered: {Settings.Instance != null}"));
+            TaleWorlds.Core.InformationManager.DisplayMessage(
+                new TaleWorlds.Core.InformationMessage("[ExtremeRagdoll] Startup loading confirmed."));
             if (_adapted) return;
             try { _adapted = ER_TOR_Adapter.TryEnableShockwaves(); }
             catch { _adapted = false; }


### PR DESCRIPTION
## Summary
- display a startup message confirming settings discovery
- add a second startup message confirming mod loading

## Testing
- not run (per instructions)

------
https://chatgpt.com/codex/tasks/task_e_68d657b2e3fc8320a42ee3981aa772d2