### PR TITLE
Improve mod startup adaptation and patch binding reliability

### DIFF
--- a/ExtremeRagdoll/SubModule.cs
+++ b/ExtremeRagdoll/SubModule.cs
@@ -1,4 +1,6 @@
 using HarmonyLib;
+using TaleWorlds.Core;
+using TaleWorlds.Library;
 using TaleWorlds.MountAndBlade;
 
 namespace ExtremeRagdoll
@@ -10,14 +12,40 @@ namespace ExtremeRagdoll
         protected override void OnSubModuleLoad()
         {
             new Harmony("extremeragdoll.patch").PatchAll();
+            Debug.Print("[ExtremeRagdoll] Harmony patch pass requested");
         }
 
         protected override void OnBeforeInitialModuleScreenSetAsRoot()
         {
-            _ = Settings.Instance; // ensure discovery at main menu
+            try
+            {
+                _ = Settings.Instance; // ensure discovery at main menu when available
+            }
+            catch
+            {
+                // MCM not installed: ignore
+            }
+
+            TryAdapt("menu");
+        }
+
+        protected override void OnGameStart(Game game, IGameStarter gameStarter)
+        {
+            TryAdapt("game_start");
+        }
+
+        private static void TryAdapt(string where)
+        {
             if (_adapted) return;
-            try { _adapted = ER_TOR_Adapter.TryEnableShockwaves(); }
-            catch { _adapted = false; }
+            try
+            {
+                _adapted = ER_TOR_Adapter.TryEnableShockwaves();
+                Debug.Print($"[ExtremeRagdoll] TOR adapter at {where}: adapted={_adapted}");
+            }
+            catch
+            {
+                _adapted = false;
+            }
         }
 
         public override void OnMissionBehaviorInitialize(Mission mission)


### PR DESCRIPTION
## Summary
- retry the TOR shockwave adapter at menu load and game start with defensive logging
- guard settings discovery so the module loads without MCM and record adapter results
- make the RegisterBlow Harmony patch search overloads to bind even when the signature changes

## Testing
- not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68d681d96280832080745c7fa2bba45d