### PR TITLE
Trigger local death blast with configurable radius

### DIFF
--- a/ExtremeRagdoll/ER_KnockbackAmplifier.cs
+++ b/ExtremeRagdoll/ER_KnockbackAmplifier.cs
@@ -98,9 +98,10 @@ namespace ExtremeRagdoll
             if (extra <= 0f) return;
             ER_Log.Info($"death shove: hadKb={hadKb} dmg={dmg} baseMag={blow.BaseMagnitude} extra={extra}");
 
-            Vec3 dir = (__instance.Position - blow.GlobalPosition).NormalizedCopy();
-            if (dir.X == 0f && dir.Y == 0f && dir.Z == 0f) dir = __instance.LookDirection;
-            dir = new Vec3(dir.X, dir.Y, dir.Z + 0.25f).NormalizedCopy();
+            Vec3 flat = __instance.Position - blow.GlobalPosition;
+            flat.Z = 0f;
+            if (flat.LengthSquared < 1e-4f) flat = __instance.LookDirection;
+            Vec3 dir = (flat.NormalizedCopy() * 0.85f + new Vec3(0f, 0f, 0.53f)).NormalizedCopy();
 
             var push = new Blow(-1)
             {
@@ -126,6 +127,19 @@ namespace ExtremeRagdoll
             }
 
             ER_Log.Info($"death shove applied to Agent#{__instance.Index} dir={dir}");
+
+            // fire local AOE blast (independent of TOR)
+            try
+            {
+                ER_DeathBlastBehavior.Instance?.RecordBlast(
+                    __instance.Position,
+                    Settings.Instance?.DeathBlastRadius ?? 3.0f,
+                    extra);
+            }
+            catch
+            {
+                // ignore
+            }
         }
     }
 

--- a/ExtremeRagdoll/Settings.cs
+++ b/ExtremeRagdoll/Settings.cs
@@ -25,5 +25,10 @@ namespace ExtremeRagdoll
         [SettingPropertyBool("Debug Logging",
             Order = 2, RequireRestart = false)]
         public bool DebugLogging { get; set; } = true;
+
+        [SettingPropertyGroup("General")]
+        [SettingPropertyFloatingInteger("Death Blast Radius", 0f, 10f, "0.0",
+            Order = 3, RequireRestart = false)]
+        public float DeathBlastRadius { get; set; } = 3.0f;
     }
 }

--- a/ExtremeRagdoll/SubModule.cs
+++ b/ExtremeRagdoll/SubModule.cs
@@ -7,12 +7,14 @@ namespace ExtremeRagdoll
 {
     public class SubModule : MBSubModuleBase
     {
-        private static bool _adapted;
+        private static bool _adapted, _patched;
 
         protected override void OnSubModuleLoad()
         {
             ER_Log.Info($"Debug logging enabled: writing to {ER_Log.LogFilePath}");
+            if (_patched) return;
             new Harmony("extremeragdoll.patch").PatchAll();
+            _patched = true;
             ER_Log.Info("OnSubModuleLoad: PatchAll requested");
         }
 
@@ -53,6 +55,16 @@ namespace ExtremeRagdoll
         public override void OnMissionBehaviorInitialize(Mission mission)
         {
             mission.AddMissionBehavior(new ER_DeathBlastBehavior());
+            if (!_adapted)
+            {
+                try
+                {
+                    _adapted = ER_TOR_Adapter.TryEnableShockwaves();
+                }
+                catch
+                {
+                }
+            }
             ER_Log.Info("MissionBehavior added: ER_DeathBlastBehavior");
         }
     }


### PR DESCRIPTION
## Summary
- trigger the death blast directly from the knockback patch so it no longer depends on TOR events
- add a configurable death blast radius setting that defaults to 3.0f
- attempt TOR adaptation again when missions initialize to catch late mission loads

## Testing
- not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68d76c42dbac8320bb7dd26fa0d00277