### PR TITLE
Fix Vec3 flattening for knockback amplifier

### DIFF
--- a/ExtremeRagdoll/ER_KnockbackAmplifier.cs
+++ b/ExtremeRagdoll/ER_KnockbackAmplifier.cs
@@ -99,8 +99,12 @@ namespace ExtremeRagdoll
             ER_Log.Info($"death shove: hadKb={hadKb} dmg={dmg} baseMag={blow.BaseMagnitude} extra={extra}");
 
             Vec3 flat = __instance.Position - blow.GlobalPosition;
-            flat.Z = 0f;
-            if (flat.LengthSquared < 1e-4f) flat = __instance.LookDirection;
+            flat = new Vec3(flat.X, flat.Y, 0f);
+            if (flat.LengthSquared < 1e-4f)
+            {
+                var look = __instance.LookDirection;
+                flat = new Vec3(look.X, look.Y, 0f);
+            }
             Vec3 dir = (flat.NormalizedCopy() * 0.85f + new Vec3(0f, 0f, 0.53f)).NormalizedCopy();
 
             var push = new Blow(-1)


### PR DESCRIPTION
## Summary
- rebuild flattened vectors instead of writing to read-only Vec3.Z when computing knockback direction
- fall back to a flattened look direction when the position delta is too small

## Testing
- not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68d772c2345c8320911b067091dd9b06