### PR TITLE
Fix death blast behavior cleanup override

### DIFF
--- a/ExtremeRagdoll/ER_DeathBlast.cs
+++ b/ExtremeRagdoll/ER_DeathBlast.cs
@@ -18,7 +18,7 @@ namespace ExtremeRagdoll
 
         public override void OnBehaviorInitialize() => Instance = this;
 
-        public override void OnMissionEnded() => Instance = null;
+        public override void OnRemoveBehavior() => Instance = null;
 
         public void RecordBlast(Vec3 center, float radius, float force)
         {


### PR DESCRIPTION
## Summary
- switch ER_DeathBlastBehavior cleanup override to OnRemoveBehavior to match the MissionBehavior API

## Testing
- not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68d78429302083208e217edd4d715076