### PR TITLE
Fix C# 7.3 incompatibility

### DIFF
--- a/ExtremeRagdoll/ER_KnockbackAmplifier.cs
+++ b/ExtremeRagdoll/ER_KnockbackAmplifier.cs
@@ -20,7 +20,8 @@ namespace ExtremeRagdoll
     [HarmonyPatch]
     internal static class ER_Amplify_RegisterBlowPatch
     {
-        internal static readonly Dictionary<int, (Vec3 dir, float mag, Vec3 pos)> _pending = new();
+        internal static readonly Dictionary<int, (Vec3 dir, float mag, Vec3 pos)> _pending =
+            new Dictionary<int, (Vec3 dir, float mag, Vec3 pos)>();
 
         [HarmonyPrepare]
         static bool Prepare()


### PR DESCRIPTION
## Summary
- replace target-typed new expression with explicit generic dictionary construction for C# 7.3 compatibility

## Testing
- not run (per instructions)

------
https://chatgpt.com/codex/tasks/task_e_68d7f95a68648320abc1c279f17c480c