### PR TITLE
Harden corpse launch scheduling guards

### DIFF
--- a/ExtremeRagdoll/ER_DeathBlast.cs
+++ b/ExtremeRagdoll/ER_DeathBlast.cs
@@ -10,11 +10,54 @@ namespace ExtremeRagdoll
     {
         private struct Blast { public Vec3 Pos; public float Radius; public float Force; public float T; }
         private struct Kick  { public Agent A; public Vec3 Dir; public float Force; public float T0; public float Dur; }
-        private struct Launch { public Agent A; public Vec3 Dir; public float Mag; public Vec3 Pos; public float T; public int Tries; }
+        private struct Launch { public Agent A; public Vec3 Dir; public float Mag; public Vec3 Pos; public float T; public int Tries; public int AgentId; }
         private readonly List<Blast> _recent = new List<Blast>();
         private readonly List<Kick>  _kicks  = new List<Kick>();
         private readonly List<Launch> _launches = new List<Launch>();
+        private readonly HashSet<int> _launchFailLogged = new HashSet<int>();
+        private readonly Dictionary<int, int> _queuedPerAgent = new Dictionary<int, int>();
         private const float TTL = 0.75f;
+
+        private void IncQueue(int agentId)
+        {
+            if (agentId < 0) return;
+            if (_queuedPerAgent.TryGetValue(agentId, out var count))
+                _queuedPerAgent[agentId] = count + 1;
+            else
+                _queuedPerAgent[agentId] = 1;
+        }
+
+        private void DecQueue(int agentId)
+        {
+            if (agentId < 0) return;
+            if (_queuedPerAgent.TryGetValue(agentId, out var count))
+            {
+                if (count <= 1)
+                    _queuedPerAgent.Remove(agentId);
+                else
+                    _queuedPerAgent[agentId] = count - 1;
+            }
+        }
+
+        private static Vec3 XYJitter(Vec3 p)
+        {
+            float jitter = ER_Config.CorpseLaunchXYJitter;
+            if (jitter <= 0f)
+                return p;
+            return new Vec3(
+                p.x + MBRandom.RandomFloatRanged(-jitter, jitter),
+                p.y + MBRandom.RandomFloatRanged(-jitter, jitter),
+                p.z);
+        }
+
+        internal static float ApplyDelayJitter(float baseDelay)
+        {
+            float jitter = ER_Config.CorpseLaunchRetryJitter;
+            if (jitter <= 0f)
+                return baseDelay;
+            float value = baseDelay + MBRandom.RandomFloatRanged(-jitter, jitter);
+            return value < 0f ? 0f : value;
+        }
 
         public static ER_DeathBlastBehavior Instance;
 
@@ -26,8 +69,10 @@ namespace ExtremeRagdoll
             _recent.Clear();
             _kicks.Clear();
             _launches.Clear();
+            _launchFailLogged.Clear();
+            _queuedPerAgent.Clear();
             // also clear any cross-behavior pending impulses
-            try { ER_Amplify_RegisterBlowPatch._pending.Clear(); } catch { }
+            ER_Amplify_RegisterBlowPatch.ClearPending();
         }
 
         public void RecordBlast(Vec3 center, float radius, float force)
@@ -45,17 +90,69 @@ namespace ExtremeRagdoll
         public void EnqueueLaunch(Agent a, Vec3 dir, float mag, Vec3 pos, float delaySec = 0.03f, int retries = 8)
         {
             if (a == null) return;
+            if (!a.IsActive()) return;
+            var mission = Mission;
+            if (mission == null) return;
+            if (a.Mission != mission) return;
+            if (ER_Config.MaxCorpseLaunchMagnitude <= 0f) return;
             if (mag <= 0f) return;
+            if (a.Health > 0f) return;
             if (delaySec < 0f) delaySec = 0f;
+            delaySec = ApplyDelayJitter(delaySec);
             if (retries < 0) retries = 0;
             if (retries > 12) retries = 12;
-            _launches.Add(new Launch { A = a, Dir = dir, Mag = mag, Pos = pos, T = Mission.CurrentTime + delaySec, Tries = retries });
+            int queueCap = ER_Config.CorpseLaunchQueueCap;
+            int agentIndex = a.Index;
+            if (queueCap > 0)
+            {
+                _queuedPerAgent.TryGetValue(agentIndex, out var queued);
+                if (queued >= queueCap) return;
+            }
+
+            float maxMag = ER_Config.MaxCorpseLaunchMagnitude;
+            if (maxMag > 0f && mag > maxMag)
+            {
+                mag = maxMag;
+            }
+            if (mag <= 0f || float.IsNaN(mag) || float.IsInfinity(mag))
+                return;
+            Vec3 safeDir = dir.LengthSquared > 1e-6f ? dir.NormalizedCopy() : new Vec3(0f, 1f, 0f);
+            safeDir = (safeDir + new Vec3(0f, 0f, 0.15f)).NormalizedCopy();
+            float safeDirSq = safeDir.LengthSquared;
+            if (safeDirSq < 1e-8f || float.IsNaN(safeDirSq) || float.IsInfinity(safeDirSq))
+                return;
+            Vec3 nudgedPos = pos;
+            float zNudge = ER_Config.CorpseLaunchZNudge;
+            float zClamp = ER_Config.CorpseLaunchZClampAbove;
+            nudgedPos.z = MathF.Min(nudgedPos.z + zNudge, a.Position.z + zClamp);
+
+            _launches.Add(new Launch { A = a, Dir = safeDir, Mag = mag, Pos = nudgedPos, T = mission.CurrentTime + delaySec, Tries = retries, AgentId = agentIndex });
+            IncQueue(agentIndex);
         }
 
         public override void OnMissionTick(float dt)
         {
-            if (Mission == null || Mission.Agents == null) return;
-            float now = Mission.CurrentTime;
+            var mission = Mission;
+            if (mission == null || mission.Agents == null) return;
+            float now = mission.CurrentTime;
+            if (ER_Config.MaxCorpseLaunchMagnitude <= 0f)
+            {
+                for (int i = _launches.Count - 1; i >= 0; i--)
+                {
+                    DecQueue(_launches[i].AgentId);
+                    _launches.RemoveAt(i);
+                }
+                return;
+            }
+            float tookScale = ER_Config.CorpseLaunchVelocityScaleThreshold;
+            float tookOffset = ER_Config.CorpseLaunchVelocityOffset;
+            float tookVertical = ER_Config.CorpseLaunchVerticalDelta;
+            float tookDisplacement = ER_Config.CorpseLaunchDisplacement;
+            float contactHeight = ER_Config.CorpseLaunchContactHeight;
+            float retryDelay = ER_Config.CorpseLaunchRetryDelay;
+            int queueCap = ER_Config.CorpseLaunchQueueCap;
+            float zNudge = ER_Config.CorpseLaunchZNudge;
+            float zClamp = ER_Config.CorpseLaunchZClampAbove;
             for (int i = _recent.Count - 1; i >= 0; i--)
                 if (now - _recent[i].T > TTL) _recent.RemoveAt(i);
             for (int i = _kicks.Count - 1; i >= 0; i--)
@@ -87,45 +184,140 @@ namespace ExtremeRagdoll
             {
                 var L = _launches[i];
                 if (now < L.T) continue;
+                var agent = L.A;
+                int agentIndex = L.AgentId >= 0 ? L.AgentId : agent?.Index ?? -1;
                 _launches.RemoveAt(i);
-                if (L.A == null || L.A.Health > 0f || L.A.Mission != Mission) continue; // only launch ragdolls still in mission
+                DecQueue(agentIndex);
+                if (agent == null)
+                {
+                    continue;
+                }
+                if (!agent.IsActive())
+                {
+                    _launchFailLogged.Remove(agentIndex);
+                    continue;
+                }
+                if (agent.Health > 0f || agent.Mission != mission)
+                {
+                    _launchFailLogged.Remove(agentIndex);
+                    continue; // only launch ragdolls still in mission
+                }
 
-                Vec3 posBefore = L.A.Position;
-                float vBefore2 = L.A.Velocity.LengthSquared;
+                Vec3 posBefore = agent.Position;
+                Vec3 velBefore = agent.Velocity;
+                float vBefore2 = velBefore.LengthSquared;
+                Vec3 dir = L.Dir.LengthSquared > 1e-8f ? L.Dir : new Vec3(0f, 1f, 0f);
+                dir = (dir + new Vec3(0f, 0f, 0.1f)).NormalizedCopy();
+                float dirSq = dir.LengthSquared;
+                if (dirSq < 1e-8f || float.IsNaN(dirSq) || float.IsInfinity(dirSq))
+                {
+                    _launchFailLogged.Remove(agentIndex);
+                    continue;
+                }
+                float mag = L.Mag;
+                float tickMax = ER_Config.MaxCorpseLaunchMagnitude;
+                if (tickMax > 0f && mag > tickMax)
+                {
+                    mag = tickMax;
+                }
+                if (mag <= 0f || float.IsNaN(mag) || float.IsInfinity(mag))
+                {
+                    _launchFailLogged.Remove(agentIndex);
+                    continue;
+                }
+                Vec3 hit = XYJitter(L.Pos);
+                Vec3 contact = hit;
+                contact.z += contactHeight;
+                contact.z = MathF.Min(contact.z, agent.Position.z + zClamp);
+
                 var blow = new Blow(-1)
                 {
                     DamageType      = DamageTypes.Blunt,
                     BlowFlag        = BlowFlags.KnockBack | BlowFlags.KnockDown | BlowFlags.NoSound,
-                    BaseMagnitude   = L.Mag,
-                    SwingDirection  = L.Dir,
-                    GlobalPosition  = L.Pos,
+                    BaseMagnitude   = mag,
+                    SwingDirection  = dir,
+                    GlobalPosition  = contact,
                     InflictedDamage = 0
                 };
                 AttackCollisionData acd = default;
-                L.A.RegisterBlow(blow, in acd);
-                float vAfter2 = L.A.Velocity.LengthSquared;
-                float moved = posBefore.Distance(L.A.Position);
-                bool took = (vAfter2 > vBefore2 + 0.05f) || (moved > 0.01f);
+                agent.RegisterBlow(blow, in acd);
+                Vec3 velAfter = agent.Velocity;
+                float vAfter2 = velAfter.LengthSquared;
+                float moved = posBefore.Distance(agent.Position);
+                bool took = (vAfter2 > vBefore2 * tookScale + tookOffset)
+                    || (velAfter.z > velBefore.z + tookVertical)
+                    || (moved > tookDisplacement);
 
-                if (!took && L.Tries > 0)
+                if (!took)
                 {
-                    L.Tries--;
-                    L.T = now + 0.06f;
-                    L.Pos = L.A.Position;
-                    _launches.Add(L);
-                    if (ER_Config.DebugLogging)
-                        ER_Log.Info($"corpse launch re-queued for Agent#{L.A.Index} tries={L.Tries}");
+                    if (ER_Config.DebugLogging && _launchFailLogged.Add(agentIndex))
+                    {
+                        float deltaZ = velAfter.z - velBefore.z;
+                        ER_Log.Info($"corpse launch miss Agent#{agentIndex} vBefore2={vBefore2:F4} vAfter2={vAfter2:F4} deltaZ={deltaZ:F4}");
+                    }
+
+                    if (L.Tries > 0)
+                    {
+                        float nextTime = now + ApplyDelayJitter(retryDelay);
+                        Vec3 retryPos = XYJitter(agent.Position);
+                        retryPos.z = MathF.Min(retryPos.z + zNudge, agent.Position.z + zClamp);
+
+                        float maxMagSetting = ER_Config.MaxCorpseLaunchMagnitude;
+                        if (maxMagSetting > 0f && L.Mag > maxMagSetting)
+                        {
+                            L.Mag = maxMagSetting;
+                        }
+
+                        bool canQueue = true;
+                        int existingQueued = 0;
+                        if (agentIndex >= 0)
+                        {
+                            _queuedPerAgent.TryGetValue(agentIndex, out existingQueued);
+                        }
+                        if (queueCap > 0 && existingQueued >= queueCap)
+                        {
+                            canQueue = false;
+                        }
+
+                        if (canQueue)
+                        {
+                            L.Tries--;
+                            L.T = nextTime;
+                            L.Pos = retryPos;
+                            L.AgentId = agentIndex;
+                            _launches.Add(L);
+                            IncQueue(agentIndex);
+                            if (ER_Config.DebugLogging && agentIndex >= 0)
+                            {
+                                _queuedPerAgent.TryGetValue(agentIndex, out var newQueuedCount);
+                                ER_Log.Info($"corpse launch re-queued for Agent#{agentIndex} tries={L.Tries} queued={newQueuedCount}");
+                            }
+                        }
+                        else if (ER_Config.DebugLogging && agentIndex >= 0)
+                        {
+                            ER_Log.Info($"corpse launch queue full for Agent#{agentIndex} tries={L.Tries} queued={existingQueued} cap={queueCap}");
+                        }
+                    }
+                    else
+                    {
+                        _launchFailLogged.Remove(agentIndex);
+                    }
                 }
-                else if (ER_Config.DebugLogging)
+                else
                 {
-                    ER_Log.Info($"death shove applied to Agent#{L.A.Index} took={took} mag={L.Mag}");
+                    _launchFailLogged.Remove(agentIndex);
+                    if (ER_Config.DebugLogging)
+                    {
+                        _queuedPerAgent.TryGetValue(agentIndex, out var queued);
+                        ER_Log.Info($"death shove applied to Agent#{agentIndex} took={took} mag={mag} tries={L.Tries} queued={queued}");
+                    }
                 }
             }
             if (_recent.Count == 0) return;
 
             const int MAX_WORK = 256;
             int worked = 0;
-            foreach (var a in Mission.Agents)
+            foreach (var a in mission.Agents)
             {
                 if (a == null || a.Health <= 0f) continue; // ragdoll corpse already handled on kill
                 bool affected = false;
@@ -137,9 +329,15 @@ namespace ExtremeRagdoll
                     if (d > b.Radius) continue;
                     float force = (b.Force * ER_Config.DeathBlastForceMultiplier) * (1f / (1f + d));
                     if (force <= 0f) continue;
-                    Vec3 flat = pos - b.Pos; flat = new Vec3(flat.X, flat.Y, 0f);
+                    Vec3 flat = pos - b.Pos; flat = new Vec3(flat.x, flat.y, 0f);
                     if (flat.LengthSquared < 1e-4f) flat = new Vec3(0f, 0f, 1f);
                     Vec3 dir = (flat.NormalizedCopy() * 0.70f + new Vec3(0f, 0f, 0.72f)).NormalizedCopy();
+                    float maxForce = ER_Config.MaxAoEForce;
+                    if (maxForce > 0f && force > maxForce)
+                    {
+                        force = maxForce;
+                    }
+
                     var aoe = new Blow(-1)
                     {
                         DamageType      = DamageTypes.Blunt,
@@ -175,28 +373,41 @@ namespace ExtremeRagdoll
         // Fire post-death fallback if MakeDead scheduling failed to consume the pending entry
         public override void OnAgentRemoved(Agent affected, Agent affector, AgentState state, KillingBlow killingBlow)
         {
-            if (affected == null || state != AgentState.Killed) return;
+            if (affected == null) return;
+            _launchFailLogged.Remove(affected.Index);
+            ER_Amplify_RegisterBlowPatch.ForgetScheduled(affected.Index);
+            if (state != AgentState.Killed) return;
+            if (affected.Mission != Mission) return;
+            if (ER_Config.MaxCorpseLaunchMagnitude <= 0f) return;
+
+            for (int i = _launches.Count - 1; i >= 0; i--)
+            {
+                var queued = _launches[i];
+                if (queued.AgentId == affected.Index || queued.A == affected)
+                {
+                    _launches.RemoveAt(i);
+                    DecQueue(affected.Index);
+                    _launchFailLogged.Remove(affected.Index);
+                }
+            }
 
             // Kontaktpunkt: konservativ das Agent-Center verwenden (kein KillingBlow.GlobalPosition vorhanden)
             Vec3 hitPos = affected.Position;
-            Vec3 flat   = affected.Position - hitPos; flat = new Vec3(flat.X, flat.Y, 0f);
-            if (flat.LengthSquared < 1e-6f) { var look = affected.LookDirection; flat = new Vec3(look.X, look.Y, 0f); }
+            Vec3 flat   = new Vec3(affected.LookDirection.x, affected.LookDirection.y, 0f);
             if (flat.LengthSquared < 1e-6f) flat = new Vec3(0f, 1f, 0f);
-            Vec3 dir = (flat.NormalizedCopy() * 0.35f + new Vec3(0f, 0f, 1.05f)).NormalizedCopy();
+            Vec3 fallbackDir = (flat.NormalizedCopy() * 0.35f + new Vec3(0f, 0f, 1.05f)).NormalizedCopy();
 
             // Fallback only if MakeDead didn’t consume the pending entry
-            if (!ER_Amplify_RegisterBlowPatch._pending.TryGetValue(affected.Index, out var p))
+            if (!ER_Amplify_RegisterBlowPatch.TryTakePending(affected.Index, out var p))
                 return;
 
-            ER_Amplify_RegisterBlowPatch._pending.Remove(affected.Index);
-
             float mag = p.mag;
-            if (p.dir.LengthSquared > 1e-6f) dir = p.dir;
+            Vec3 dir = p.dir.LengthSquared > 1e-6f ? p.dir : fallbackDir;
             if (p.pos.LengthSquared > 1e-6f) hitPos = p.pos;
 
             // Schedule with retries (safety net in case MakeDead timing was late)
-            EnqueueLaunch(affected, dir, mag,                         hitPos, ER_Config.LaunchDelay1, retries: 8);
-            EnqueueLaunch(affected, dir, mag * ER_Config.LaunchPulse2Scale, hitPos, ER_Config.LaunchDelay2, retries: 4);
+            EnqueueLaunch(affected, dir, mag,                         hitPos, ER_Config.LaunchDelay1, retries: 6);
+            EnqueueLaunch(affected, dir, mag * ER_Config.LaunchPulse2Scale, hitPos, ER_Config.LaunchDelay2, retries: 3);
             EnqueueKick  (affected, dir, mag, 1.2f);
             RecordBlast(affected.Position, ER_Config.DeathBlastRadius, mag);
             if (ER_Config.DebugLogging)

--- a/ExtremeRagdoll/Settings.cs
+++ b/ExtremeRagdoll/Settings.cs
@@ -39,16 +39,86 @@ namespace ExtremeRagdoll
         [SettingPropertyGroup("Advanced")]
         [SettingPropertyFloatingInteger("Corpse Launch Delay #1 (s)", 0f, 0.25f, "0.00",
             Order = 100, RequireRestart = false)]
-        public float LaunchDelay1 { get; set; } = 0.06f;
+        public float LaunchDelay1 { get; set; } = 0.02f;
 
         [SettingPropertyGroup("Advanced")]
         [SettingPropertyFloatingInteger("Corpse Launch Delay #2 (s)", 0f, 0.30f, "0.00",
             Order = 101, RequireRestart = false)]
-        public float LaunchDelay2 { get; set; } = 0.14f;
+        public float LaunchDelay2 { get; set; } = 0.07f;
 
         [SettingPropertyGroup("Advanced")]
         [SettingPropertyFloatingInteger("Second Pulse Scale", 0f, 2.0f, "0.00",
             Order = 102, RequireRestart = false)]
         public float LaunchPulse2Scale { get; set; } = 0.80f;
+
+        [SettingPropertyGroup("Advanced")]
+        [SettingPropertyFloatingInteger("Corpse Launch Velocity Scale Threshold", 1.0f, 2.0f, "0.00",
+            Order = 103, RequireRestart = false)]
+        public float CorpseLaunchVelocityScaleThreshold { get; set; } = 1.02f;
+
+        [SettingPropertyGroup("Advanced")]
+        [SettingPropertyFloatingInteger("Corpse Launch Velocity Offset", 0f, 1f, "0.000",
+            Order = 104, RequireRestart = false)]
+        public float CorpseLaunchVelocityOffset { get; set; } = 0.01f;
+
+        [SettingPropertyGroup("Advanced")]
+        [SettingPropertyFloatingInteger("Corpse Launch Vertical Delta", 0f, 1f, "0.000",
+            Order = 105, RequireRestart = false)]
+        public float CorpseLaunchVerticalDelta { get; set; } = 0.05f;
+
+        [SettingPropertyGroup("Advanced")]
+        [SettingPropertyFloatingInteger("Corpse Launch Displacement Threshold", 0f, 0.5f, "0.000",
+            Order = 106, RequireRestart = false)]
+        public float CorpseLaunchDisplacement { get; set; } = 0.005f;
+
+        [SettingPropertyGroup("Advanced")]
+        [SettingPropertyFloatingInteger("Max Corpse Launch Magnitude", 0f, 500_000_000f, "0.0",
+            Order = 107, RequireRestart = false)]
+        public float MaxCorpseLaunchMagnitude { get; set; } = 200_000_000f;
+
+        [SettingPropertyGroup("Advanced")]
+        [SettingPropertyFloatingInteger("Max AOE Force", 0f, 500_000_000f, "0.0",
+            Order = 108, RequireRestart = false)]
+        public float MaxAoEForce { get; set; } = 200_000_000f;
+
+        [SettingPropertyGroup("Advanced")]
+        [SettingPropertyFloatingInteger("Max Non-Lethal Knockback", 0f, 500_000_000f, "0.0",
+            Order = 109, RequireRestart = false)]
+        public float MaxNonLethalKnockback { get; set; } = 0f;
+
+        [SettingPropertyGroup("Advanced")]
+        [SettingPropertyFloatingInteger("Corpse Launch XY Jitter", 0f, 0.5f, "0.000",
+            Order = 110, RequireRestart = false)]
+        public float CorpseLaunchXYJitter { get; set; } = 0.003f;
+
+        [SettingPropertyGroup("Advanced")]
+        [SettingPropertyFloatingInteger("Corpse Launch Z Nudge", 0f, 0.5f, "0.000",
+            Order = 111, RequireRestart = false)]
+        public float CorpseLaunchZNudge { get; set; } = 0.05f;
+
+        [SettingPropertyGroup("Advanced")]
+        [SettingPropertyFloatingInteger("Corpse Launch Z Clamp Above", 0f, 1.0f, "0.000",
+            Order = 112, RequireRestart = false)]
+        public float CorpseLaunchZClampAbove { get; set; } = 0.12f;
+
+        [SettingPropertyGroup("Advanced")]
+        [SettingPropertyFloatingInteger("Corpse Launch Contact Height", 0f, 1.0f, "0.000",
+            Order = 113, RequireRestart = false)]
+        public float CorpseLaunchContactHeight { get; set; } = 0.35f;
+
+        [SettingPropertyGroup("Advanced")]
+        [SettingPropertyFloatingInteger("Corpse Launch Retry Delay (s)", 0f, 0.5f, "0.000",
+            Order = 114, RequireRestart = false)]
+        public float CorpseLaunchRetryDelay { get; set; } = 0.045f;
+
+        [SettingPropertyGroup("Advanced")]
+        [SettingPropertyFloatingInteger("Corpse Launch Retry Jitter (s)", 0f, 0.5f, "0.000",
+            Order = 115, RequireRestart = false)]
+        public float CorpseLaunchRetryJitter { get; set; } = 0.005f;
+
+        [SettingPropertyGroup("Advanced")]
+        [SettingPropertyInteger("Corpse Launch Queue Cap", 0, 20,
+            Order = 116, RequireRestart = false)]
+        public int CorpseLaunchQueueCap { get; set; } = 3;
     }
 }


### PR DESCRIPTION
## Summary
- guard corpse launch enqueueing against inactive or cross-mission agents, jitter launch delays, and bail on non-finite magnitudes before registering corpse blows
- split configurable magnitude caps for corpse launches, non-lethal knockback, and AOE pulses while defaulting the non-lethal cap to uncapped values
- harden the death scheduling patch with a reusable run-once helper so MakeDead overload patches compile cleanly without double-queueing launches

## Testing
- not run (per instructions)

------
https://chatgpt.com/codex/tasks/task_e_68d82a90d5dc83209e67c0912abbbe6f