### PR TITLE
Allow corpse launch scheduling for removed agents

### DIFF
--- a/ExtremeRagdoll/ER_DeathBlast.cs
+++ b/ExtremeRagdoll/ER_DeathBlast.cs
@@ -60,7 +60,7 @@ namespace ExtremeRagdoll
         private const float TTL = 0.75f;
 
         // --- API shims for TaleWorlds versions lacking these helpers ---
-        private static bool AgentRemoved(Agent a) => a == null || a.Mission == null || !a.IsActive();
+        private static bool AgentRemoved(Agent a) => a == null || a.Mission == null;
         private static PropertyInfo _ragdollProp;
         private static bool RagdollActive(Agent a)
         {


### PR DESCRIPTION
## Summary
- loosen the AgentRemoved helper so corpse launch scheduling can proceed after the agent becomes inactive

## Testing
- not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68d9e48546f08320b95efa4a571da296