### PR TITLE
Ensure reflection import, stabilize RegisterBlow binding, and keep lethal zero-damage missiles

### DIFF
--- a/ExtremeRagdoll/Settings.cs
+++ b/ExtremeRagdoll/Settings.cs
@@ -82,98 +82,103 @@ namespace ExtremeRagdoll
         public float MaxAoEForce { get; set; } = 200_000_000f;
 
         [SettingPropertyGroup("Advanced")]
-        [SettingPropertyFloatingInteger("Max Non-Lethal Knockback", 0f, 500_000_000f, "0.0",
+        [SettingPropertyFloatingInteger("Max Blow Base Magnitude", 0f, 500_000_000f, "0.0",
             Order = 109, RequireRestart = false)]
+        public float MaxBlowBaseMagnitude { get; set; } = 0f;
+
+        [SettingPropertyGroup("Advanced")]
+        [SettingPropertyFloatingInteger("Max Non-Lethal Knockback", 0f, 500_000_000f, "0.0",
+            Order = 110, RequireRestart = false)]
         public float MaxNonLethalKnockback { get; set; } = 0f;
 
         [SettingPropertyGroup("Advanced")]
         [SettingPropertyFloatingInteger("Corpse Launch XY Jitter", 0f, 0.5f, "0.000",
-            Order = 110, RequireRestart = false)]
+            Order = 111, RequireRestart = false)]
         public float CorpseLaunchXYJitter { get; set; } = 0.003f;
 
         [SettingPropertyGroup("Advanced")]
         [SettingPropertyFloatingInteger("Corpse Launch Z Nudge", 0f, 0.5f, "0.000",
-            Order = 111, RequireRestart = false)]
+            Order = 112, RequireRestart = false)]
         public float CorpseLaunchZNudge { get; set; } = 0.05f;
 
         [SettingPropertyGroup("Advanced")]
         [SettingPropertyFloatingInteger("Corpse Launch Z Clamp Above", 0f, 1.0f, "0.000",
-            Order = 112, RequireRestart = false)]
+            Order = 113, RequireRestart = false)]
         public float CorpseLaunchZClampAbove { get; set; } = 0.18f;
 
         [SettingPropertyGroup("Advanced")]
         [SettingPropertyFloatingInteger("Corpse Launch Contact Height", 0f, 1.0f, "0.000",
-            Order = 113, RequireRestart = false)]
+            Order = 114, RequireRestart = false)]
         public float CorpseLaunchContactHeight { get; set; } = 0.35f;
 
         [SettingPropertyGroup("Advanced")]
         [SettingPropertyFloatingInteger("Corpse Launch Retry Delay (s)", 0f, 0.5f, "0.000",
-            Order = 114, RequireRestart = false)]
+            Order = 115, RequireRestart = false)]
         public float CorpseLaunchRetryDelay { get; set; } = 0.02f;
 
         [SettingPropertyGroup("Advanced")]
         [SettingPropertyFloatingInteger("Corpse Launch Retry Jitter (s)", 0f, 0.5f, "0.000",
-            Order = 115, RequireRestart = false)]
+            Order = 116, RequireRestart = false)]
         public float CorpseLaunchRetryJitter { get; set; } = 0.005f;
 
         [SettingPropertyGroup("Advanced")]
         [SettingPropertyInteger("Corpse Launch Queue Cap", 0, 20,
-            Order = 116, RequireRestart = false)]
+            Order = 117, RequireRestart = false)]
         public int CorpseLaunchQueueCap { get; set; } = 3;
 
         [SettingPropertyGroup("Advanced")]
         [SettingPropertyFloatingInteger("Minimum Corpse Impulse", 0f, 500_000f, "0.0",
-            Order = 117, RequireRestart = false)]
+            Order = 118, RequireRestart = false)]
         public float CorpseImpulseMinimum { get; set; } = 0.5f;
 
         [SettingPropertyGroup("Advanced")]
         [SettingPropertyFloatingInteger("Maximum Corpse Impulse", 0f, 2_000_000f, "0.0",
-            Order = 118, RequireRestart = false)]
+            Order = 119, RequireRestart = false)]
         public float CorpseImpulseMaximum { get; set; } = 1_500f;
 
         [SettingPropertyGroup("Advanced")]
         [SettingPropertyFloatingInteger("Corpse Launch Max Up Fraction", 0f, 1.0f, "0.00",
-            Order = 119, RequireRestart = false)]
+            Order = 120, RequireRestart = false)]
         public float CorpseLaunchMaxUpFraction { get; set; } = 0.22f;
 
         [SettingPropertyGroup("Advanced")]
         [SettingPropertyInteger("Corpse Prelaunch Tries", 0, 100,
-            Order = 120, RequireRestart = false)]
+            Order = 121, RequireRestart = false)]
         public int CorpsePrelaunchTries { get; set; } = 12;
 
         [SettingPropertyGroup("Advanced")]
         [SettingPropertyInteger("Corpse Post-Death Launch Tries", 0, 100,
-            Order = 121, RequireRestart = false)]
+            Order = 122, RequireRestart = false)]
         public int CorpsePostDeathTries { get; set; } = 12;
 
         [SettingPropertyGroup("Advanced")]
         [SettingPropertyInteger("Max Corpse Launches Per Tick", 0, 2048,
-            Order = 122, RequireRestart = false)]
+            Order = 123, RequireRestart = false)]
         public int CorpseLaunchesPerTick { get; set; } = 128;
 
         [SettingPropertyGroup("Advanced")]
         [SettingPropertyInteger("Max AoE Agents Per Tick", 0, 4096,
-            Order = 123, RequireRestart = false)]
+            Order = 124, RequireRestart = false)]
         public int AoEAgentsPerTick { get; set; } = 256;
 
         [SettingPropertyGroup("Advanced")]
         [SettingPropertyInteger("Max Kick Impulses Per Tick", 0, 2048,
-            Order = 124, RequireRestart = false)]
+            Order = 125, RequireRestart = false)]
         public int KicksPerTick { get; set; } = 128;
 
         [SettingPropertyGroup("Advanced")]
         [SettingPropertyFloatingInteger("Corpse Launch Schedule Window (s)", 0f, 0.5f, "0.00",
-            Order = 125, RequireRestart = false)]
+            Order = 126, RequireRestart = false)]
         public float CorpseLaunchScheduleWindow { get; set; } = 0.08f;
 
         [SettingPropertyGroup("Advanced")]
         [SettingPropertyFloatingInteger("Death Blast Memory (s)", 0f, 5f, "0.00",
-            Order = 126, RequireRestart = false)]
+            Order = 127, RequireRestart = false)]
         public float DeathBlastTtl { get; set; } = 0.75f;
 
         [SettingPropertyGroup("Advanced")]
         [SettingPropertyBool("Respect Engine Blow Flags",
-            Order = 127, RequireRestart = false)]
+            Order = 128, RequireRestart = false)]
         public bool RespectEngineBlowFlags { get; set; } = false;
     }
 }


### PR DESCRIPTION
## Summary
- ensure the knockback amplifier explicitly imports `System.Reflection` with the other System namespaces
- bump the advanced settings display order values so each entry keeps a unique slot after adding the new option
- mark the Harmony prefix target method explicitly and emit optional debug logging when lethal boosts are applied
- keep lethal zero-damage spell kills eligible for pending launches by resolving missile speed before early exit and reuse that value when boosting lethal blows
- clamp lethal engine shove base magnitude after multiplying so the configurable cap still applies with extra force multipliers

## Testing
- not run (per instructions)

------
https://chatgpt.com/codex/tasks/task_e_68dba79c80488320afc647d7605e2a48