### PR TITLE
Remove redundant RegisterBlow patch guard

### DIFF
--- a/ExtremeRagdoll/ER_KnockbackAmplifier.cs
+++ b/ExtremeRagdoll/ER_KnockbackAmplifier.cs
@@ -141,7 +141,6 @@ namespace ExtremeRagdoll
         private static readonly FieldInfo VelocityField = typeof(AttackCollisionData).GetField("Velocity", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
         private static readonly PropertyInfo MissileVelocityProperty = typeof(AttackCollisionData).GetProperty("MissileVelocity", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
         private static readonly PropertyInfo VelocityProperty = typeof(AttackCollisionData).GetProperty("Velocity", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
-        private static bool _patched;
 
         private static float ResolveMissileSpeed(AttackCollisionData data)
         {
@@ -271,9 +270,6 @@ namespace ExtremeRagdoll
         [HarmonyPrepare]
         static bool Prepare()
         {
-            if (_patched)
-                return false;
-
             var method = TargetMethod();
             if (method == null)
             {
@@ -288,7 +284,6 @@ namespace ExtremeRagdoll
             }
 
             ER_Log.Info("Patching: " + method);
-            _patched = true;
             return true;
         }
 


### PR DESCRIPTION
## Summary
- remove the cached `_patched` guard so `HarmonyPrepare` keeps enabling the RegisterBlow patch
- rely on Harmony's own tracking to avoid double-applying the patch while retaining diagnostics when the target is missing

## Testing
- not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68dbdeddf0ec83208bcc93cb9f129b4d