### PR TITLE
Remove skeleton-only frame fallbacks

### DIFF
--- a/ExtremeRagdoll/ER_DeathBlast.cs
+++ b/ExtremeRagdoll/ER_DeathBlast.cs
@@ -858,10 +858,6 @@ namespace ExtremeRagdoll
                 {
                     try { skel = agent?.AgentVisuals?.GetSkeleton(); } catch { }
                 }
-                if (skel == null)
-                {
-                    try { skel = ent?.GetSkeleton(); } catch { }
-                }
                 L.Ent  = ent;
                 L.Skel = skel;
                 bool agentMissing = agent == null || agent.Mission == null || agent.Mission != mission;

--- a/ExtremeRagdoll/ER_ImpulseRouter.cs
+++ b/ExtremeRagdoll/ER_ImpulseRouter.cs
@@ -150,7 +150,7 @@ namespace ExtremeRagdoll
                 {
                     try
                     {
-                        if (ER_Space.TryWorldToLocal(skel, worldImpulse, worldPos, out var impL, out var posL))
+                        if (ER_Space.TryWorldToLocal(ent, worldImpulse, worldPos, out var impL, out var posL))
                         {
                             if (_dSk2 != null)
                                 _dSk2(skel, impL, posL);
@@ -207,21 +207,5 @@ namespace ExtremeRagdoll
             } catch { return false; }
         }
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool TryWorldToLocal(Skeleton skel, in Vec3 wImp, in Vec3 wPos, out Vec3 lImp, out Vec3 lPos)
-        {
-            lImp = wImp;
-            lPos = wPos;
-            if (skel == null)
-                return false;
-            try {
-                MatrixFrame frame;
-                try { frame = skel.GetFrame(); }
-                catch { frame = default; }
-                lPos = frame.TransformToLocal(wPos);
-                lImp = frame.TransformToLocal(wPos + wImp) - lPos;
-                return true;
-            } catch { return false; }
-        }
     }
 }


### PR DESCRIPTION
## Summary
- stop relying on GameEntity.GetSkeleton() when refreshing cached launch targets
- reuse the GameEntity frame conversion for skeleton impulses so Skeleton.GetFrame() is no longer required

## Testing
- not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68dce2df61348320819910ffab78d80b