### PR TITLE
Rename fallback corpse launch retry variable

### DIFF
--- a/ExtremeRagdoll/ER_DeathBlast.cs
+++ b/ExtremeRagdoll/ER_DeathBlast.cs
@@ -1409,9 +1409,9 @@ namespace ExtremeRagdoll
                 float m = MathF.Min(12000f, ER_Config.MaxBlowBaseMagnitude > 0f
                     ? ER_Config.MaxBlowBaseMagnitude : 12000f);
                 var pos0 = affected.Position;
-                int postTries = ER_Config.CorpsePostDeathTries;
-                int pulse2 = Math.Max(0, (int)MathF.Round(postTries * MathF.Max(0f, ER_Config.LaunchPulse2Scale)));
-                EnqueueLaunch(affected, d, m,                         pos0, ER_Config.LaunchDelay1, retries: postTries);
+                int postTriesSynth = ER_Config.CorpsePostDeathTries;
+                int pulse2 = Math.Max(0, (int)MathF.Round(postTriesSynth * MathF.Max(0f, ER_Config.LaunchPulse2Scale)));
+                EnqueueLaunch(affected, d, m,                         pos0, ER_Config.LaunchDelay1, retries: postTriesSynth);
                 EnqueueLaunch(affected, d, m * ER_Config.LaunchPulse2Scale, pos0, ER_Config.LaunchDelay2, retries: pulse2);
                 EnqueueKick  (affected, d, m, 1.2f);
                 if (ER_Config.DebugLogging)


### PR DESCRIPTION
## Summary
- rename the synthesized fallback corpse launch retry counter to avoid shadowing the later variable and resolve CS0136

## Testing
- not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68dd2818b1e88320a05bb5cad7b0671e