### PR TITLE
Fix corpse impulse routing and warmup blast strength

### DIFF
--- a/ExtremeRagdoll/ER_DeathBlast.cs
+++ b/ExtremeRagdoll/ER_DeathBlast.cs
@@ -974,9 +974,9 @@ namespace ExtremeRagdoll
                     var blow = new Blow(-1)
                     {
                         DamageType      = DamageTypes.Blunt,
-                        // Ragdoll activation only. Do not impart engine knockback here.
-                        BlowFlag        = BlowFlags.KnockDown | BlowFlags.NoSound,
-                        BaseMagnitude   = 1f,
+                        // Seed motion so ragdoll is fully dynamic even if physics impulse route fails.
+                        BlowFlag        = BlowFlags.KnockBack | BlowFlags.KnockDown | BlowFlags.NoSound,
+                        BaseMagnitude   = MathF.Max(1f, ER_Config.WarmupBlowBaseMagnitude),
                         SwingDirection  = dir,
                         GlobalPosition  = contactPoint,
                         InflictedDamage = 0

--- a/ExtremeRagdoll/ER_ImpulseRouter.cs
+++ b/ExtremeRagdoll/ER_ImpulseRouter.cs
@@ -325,7 +325,9 @@ namespace ExtremeRagdoll
                 return false;
             }
 
-            bool canEnt = ent != null && LooksDynamic(ent) && AabbSane(ent);
+            // Corpses often report IsDynamicBody=false even though entity routes work.
+            // Do not gate on IsDynamicBody; only require a sane entity.
+            bool canEnt = ent != null && AabbSane(ent);
             bool forceEntity = ER_ImpulsePrefs.ForceEntityImpulse;
             bool allowFallbackWhenInvalid = ER_ImpulsePrefs.AllowSkeletonFallbackForInvalidEntity;
             bool skeletonAvailable = skel != null;
@@ -339,7 +341,7 @@ namespace ExtremeRagdoll
 
             // Prefer entity routes; skeleton paths are handled as a fallback below when permitted.
 
-            if (haveContact && canEnt && !_ent3Unsafe && (_dEnt3Inst != null || _ent3Inst != null))
+            if (haveContact && ent != null && canEnt && !_ent3Unsafe && (_dEnt3Inst != null || _ent3Inst != null))
             {
                 try
                 {
@@ -373,7 +375,7 @@ namespace ExtremeRagdoll
                 }
             }
 
-            if (haveContact && canEnt && !_ent3Unsafe && (_dEnt3 != null || _ent3 != null))
+            if (haveContact && ent != null && canEnt && !_ent3Unsafe && (_dEnt3 != null || _ent3 != null))
             {
                 try
                 {
@@ -407,7 +409,7 @@ namespace ExtremeRagdoll
                 }
             }
 
-            if (haveContact && canEnt && !_ent2Unsafe && (_dEnt2Inst != null || _ent2Inst != null))
+            if (haveContact && ent != null && canEnt && !_ent2Unsafe && (_dEnt2Inst != null || _ent2Inst != null))
             {
                 try
                 {
@@ -428,7 +430,7 @@ namespace ExtremeRagdoll
                 }
             }
 
-            if (haveContact && canEnt && !_ent2Unsafe && (_dEnt2 != null || _ent2 != null))
+            if (haveContact && ent != null && canEnt && !_ent2Unsafe && (_dEnt2 != null || _ent2 != null))
             {
                 try
                 {
@@ -449,7 +451,7 @@ namespace ExtremeRagdoll
                 }
             }
 
-            if (canEnt && !_ent1Unsafe && (_dEnt1Inst != null || _ent1Inst != null))
+            if (ent != null && canEnt && !_ent1Unsafe && (_dEnt1Inst != null || _ent1Inst != null))
             {
                 try
                 {
@@ -467,7 +469,7 @@ namespace ExtremeRagdoll
                 }
             }
 
-            if (canEnt && !_ent1Unsafe && (_dEnt1 != null || _ent1 != null))
+            if (ent != null && canEnt && !_ent1Unsafe && (_dEnt1 != null || _ent1 != null))
             {
                 try
                 {

--- a/ExtremeRagdoll/ER_KnockbackAmplifier.cs
+++ b/ExtremeRagdoll/ER_KnockbackAmplifier.cs
@@ -44,11 +44,8 @@ namespace ExtremeRagdoll
         {
             get
             {
-                float value = Settings.Instance?.WarmupBlowBaseMagnitude ?? 1f;
-                if (float.IsNaN(value) || float.IsInfinity(value) || value < 0f)
-                    return 0f;
-                if (value > 5f)
-                    return 5f;
+                float value = Settings.Instance?.WarmupBlowBaseMagnitude ?? 10000f;
+                if (float.IsNaN(value) || float.IsInfinity(value) || value < 0f) return 0f;
                 return value;
             }
         }

--- a/ExtremeRagdoll/Settings.cs
+++ b/ExtremeRagdoll/Settings.cs
@@ -92,9 +92,9 @@ namespace ExtremeRagdoll
         public float MaxNonLethalKnockback { get; set; } = 0f;
 
         [SettingPropertyGroup("Advanced")]
-        [SettingPropertyFloatingInteger("Warmup Blow Base Magnitude", 0f, 10f, "0.00",
+        [SettingPropertyFloatingInteger("Warmup Blow Base Magnitude", 0f, 100000f, "0.0",
             Order = 111, RequireRestart = false)]
-        public float WarmupBlowBaseMagnitude { get; set; } = 1f;
+        public float WarmupBlowBaseMagnitude { get; set; } = 10000f;
 
         [SettingPropertyGroup("Advanced")]
         [SettingPropertyFloatingInteger("Horse Ram Knockdown Threshold", 0f, 500_000_000f, "0.0",


### PR DESCRIPTION
## Summary
- allow entity impulse routes for corpses by bypassing the IsDynamicBody gate while keeping AABB sanity checks
- restore the post-death warmup blow's knockback using the configurable magnitude to ensure ragdolls start moving
- widen the warmup magnitude setting range/default so warm blows can impart meaningful force

## Testing
- not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68de34abae5c8320abd2e358b55263ff