### PR TITLE
Fix build regressions on older engine APIs

### DIFF
--- a/ExtremeRagdoll/ER_ImpulseRouter.cs
+++ b/ExtremeRagdoll/ER_ImpulseRouter.cs
@@ -67,10 +67,9 @@ namespace ExtremeRagdoll
         {
             try
             {
-                var aabb = ent.GetBoundingBox();
-                var mn = aabb.Min;
-                var mx = aabb.Max;
-                if (!ER_Math.IsFinite(mn) || !ER_Math.IsFinite(mx)) return false;
+                var mn = ent.GetPhysicsBoundingBoxMin();
+                var mx = ent.GetPhysicsBoundingBoxMax();
+                if (!ER_Math.IsFinite(in mn) || !ER_Math.IsFinite(in mx)) return false;
 
                 var d = mx - mn;
                 if (d.x <= 0f || d.y <= 0f || d.z <= 0f) return false;

--- a/ExtremeRagdoll/ER_KnockbackAmplifier.cs
+++ b/ExtremeRagdoll/ER_KnockbackAmplifier.cs
@@ -479,7 +479,7 @@ namespace ExtremeRagdoll
             if (lethal)
             {
                 // Remove engine knockback so physics impulses drive motion post-death.
-                blow.BlowFlag &= ~(BlowFlags.KnockBack | BlowFlags.KnockBackNoInterrupt);
+                blow.BlowFlag &= ~BlowFlags.KnockBack;
                 blow.BlowFlag |= BlowFlags.KnockDown | BlowFlags.NoSound;
                 if (ER_Config.DebugLogging)
                 {


### PR DESCRIPTION
## Summary
- remove the KnockBackNoInterrupt flag usage so lethal blows compile against engines lacking that enum
- fall back to GetPhysicsBoundingBoxMin/Max to validate entity AABBs without newer extension methods

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68de41ee168c8320a40c84a10528da0f