### PR TITLE
Reset launch bookkeeping on mission shutdown

### DIFF
--- a/ExtremeRagdoll/ER_KnockbackAmplifier.cs
+++ b/ExtremeRagdoll/ER_KnockbackAmplifier.cs
@@ -478,22 +478,22 @@ namespace ExtremeRagdoll
 
             if (lethal)
             {
-                // Remove engine knockback so physics impulses drive motion post-death.
+                // Let physics impulses drive motion; keep ragdoll/no-sound only.
                 blow.BlowFlag &= ~BlowFlags.KnockBack;
                 blow.BlowFlag |= BlowFlags.KnockDown | BlowFlags.NoSound;
+
                 if (ER_Config.DebugLogging)
                 {
                     float nowLog = timeNow;
                     if (nowLog - _lastAnyLog > 0.5f)
                     {
                         _lastAnyLog = nowLog;
-                        ER_Log.Info("[ER] LethalStrip: removed engine KB");
+                        ER_Log.Info("[ER] LethalKeep: engine KB stripped");
                     }
                 }
 
-                if (blow.SwingDirection.LengthSquared <= 1e-6f)
-                    blow.SwingDirection = dir;
-                blow.SwingDirection = ER_DeathBlastBehavior.FinalizeImpulseDir(blow.SwingDirection);
+                var lethalDir = ER_DeathBlastBehavior.PrepDir(dir, 0.95f, 0.05f);
+                blow.SwingDirection = ER_DeathBlastBehavior.FinalizeImpulseDir(lethalDir);
             }
             // Apply magnitude floors even when respecting engine flags
             if (!lethal)


### PR DESCRIPTION
## Summary
- stop gating contact entity impulses on AABB sanity checks and disable the crash-prone ent1 route
- strip engine knockback on lethal blows so physics impulses drive motion while preserving a clamped fallback direction
- bind skeleton impulse methods via alternate reflection names, allow fallback even when an entity exists, and ensure the impulse-only skeleton route runs when no contact point is available
- dequeue corpse launch entries immediately after successful impulses to avoid double-processing and animation conflicts
- drop agent-removed fallback launches after successful impulses so they cannot requeue and fight animations
- reset launch bookkeeping collections during mission deactivation so cross-round attempts do not leak between missions, including clearing cached launch queues and pending RegisterBlow impulses

## Testing
- not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68de47cb8d448320b4be38cbaf122c0c