### PR TITLE
Fix AABB validation for legacy engine builds

### DIFF
--- a/ExtremeRagdoll/ER_ImpulseRouter.cs
+++ b/ExtremeRagdoll/ER_ImpulseRouter.cs
@@ -81,8 +81,13 @@ namespace ExtremeRagdoll
         {
             try
             {
-                ent.GetBoundingBoxMinMax(out var mn, out var mx);
-                return mn.IsValid && mx.IsValid && (mx - mn).LengthSquared > 1e-6f;
+                var mn = ent.GetPhysicsBoundingBoxMin();
+                var mx = ent.GetPhysicsBoundingBoxMax();
+                if (!ER_Math.IsFinite(in mn) || !ER_Math.IsFinite(in mx))
+                    return false;
+
+                var d = mx - mn;
+                return d.x > 0f && d.y > 0f && d.z > 0f && d.LengthSquared > 1e-6f;
             }
             catch
             {


### PR DESCRIPTION
## Summary
- swap AabbSane to use the long-standing physics bounding box getters
- add finite guards and basic axis length checks before trusting the extents

## Testing
- not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68df1af05058832081b59cb4a4d734a0