### PR TITLE
Harden impulse routing safety checks

### DIFF
--- a/ExtremeRagdoll/ER_KnockbackAmplifier.cs
+++ b/ExtremeRagdoll/ER_KnockbackAmplifier.cs
@@ -17,7 +17,7 @@ namespace ExtremeRagdoll
         public static bool  DebugLogging              => Settings.Instance?.DebugLogging ?? false;
         public static bool  RespectEngineBlowFlags    => Settings.Instance?.RespectEngineBlowFlags ?? false;
         public static bool  ForceEntityImpulse        => Settings.Instance?.ForceEntityImpulse ?? true;
-        public static bool  AllowSkeletonFallbackForInvalidEntity => Settings.Instance?.AllowSkeletonFallbackForInvalidEntity ?? true;
+        public static bool  AllowSkeletonFallbackForInvalidEntity => Settings.Instance?.AllowSkeletonFallbackForInvalidEntity ?? false;
         public static float MinMissileSpeedForPush    => MathF.Max(0f, Settings.Instance?.MinMissileSpeedForPush ?? 5f);
         public static bool  BlockedMissilesCanPush    => Settings.Instance?.BlockedMissilesCanPush ?? false;
         public static float LaunchDelay1              => Settings.Instance?.LaunchDelay1 ?? 0.02f;

--- a/ExtremeRagdoll/Settings.cs
+++ b/ExtremeRagdoll/Settings.cs
@@ -204,12 +204,12 @@ namespace ExtremeRagdoll
         [SettingPropertyGroup("Advanced")]
         [SettingPropertyBool("Force Entity-Space Impulses",
             Order = 133, RequireRestart = false)]
-        public bool ForceEntityImpulse { get; set; } = false; // allow skeleton fallback
+        public bool ForceEntityImpulse { get; set; } = true; // disable skeleton fallback on TW branch
 
         [SettingPropertyGroup("Advanced")]
         [SettingPropertyBool("Allow Skeleton Fallback When Entity Missing/Invalid",
             Order = 134, RequireRestart = false)]
-        public bool AllowSkeletonFallbackForInvalidEntity { get; set; } = true;
+        public bool AllowSkeletonFallbackForInvalidEntity { get; set; } = false;
 
         [SettingPropertyGroup("Advanced")]
         [SettingPropertyBool("Respect Engine Blow Flags",


### PR DESCRIPTION
## Summary
- make LooksDynamic rely on engine/flags while failing open if state is unknown and log when the IsDynamic helper throws
- require dynamic, sane bodies before routing impulses through entity entry points with a hard safety gate and bail when no contact is available now that COM is disabled
- fail-close AABB sanity checks, log bounding boxes for blocked routes, and disable the COM fallback on this TW branch while forcing entity-only routing defaults

## Testing
- not run (per instructions)

------
https://chatgpt.com/codex/tasks/task_e_68df4ab70be083208754adcf2ec912e4