### PR TITLE
Allow ent2 impulses when dynamic status is unknown

### DIFF
--- a/ExtremeRagdoll/ER_ImpulseRouter.cs
+++ b/ExtremeRagdoll/ER_ImpulseRouter.cs
@@ -285,6 +285,7 @@ namespace ExtremeRagdoll
                 var skExt =
                     skAsm.GetType("TaleWorlds.Engine.SkeletonExtensions") ??
                     skAsm.GetType("TaleWorlds.Engine.Extensions.SkeletonExtensions") ??
+                    skAsm.GetType("TaleWorlds.Engine.ManagedExtensions.SkeletonExtensions") ??
                     skAsm.GetType("TaleWorlds.Engine.SkeletonPhysicsExtensions");
 
                 if (skExt != null)
@@ -602,7 +603,9 @@ namespace ExtremeRagdoll
                 catch { }
             }
             // Keep ent2/ent3 on sane AABB; ent2 only skips dyn gating when IsDynamicBody is unavailable.
-            if (!dynOk && !allowSkeletonNow)
+            // Only block ent2/ent3 when the engine definitively reports a static body.
+            bool dynKnownNotDynamic = (_isDyn != null) && !dynOk;
+            if (dynKnownNotDynamic && !allowSkeletonNow)
             {
                 Log($"IMPULSE_SKIP: no safe route (dyn={dynOk} aabb={aabbOk})");
                 return false;

--- a/ExtremeRagdoll/ER_KnockbackAmplifier.cs
+++ b/ExtremeRagdoll/ER_KnockbackAmplifier.cs
@@ -64,7 +64,7 @@ namespace ExtremeRagdoll
         {
             get
             {
-                float cap = Settings.Instance?.CorpseImpulseHardCap ?? 30f;
+                float cap = Settings.Instance?.CorpseImpulseHardCap ?? 60f;
                 if (float.IsNaN(cap) || float.IsInfinity(cap) || cap <= 0f)
                     return 0f;
                 return cap;

--- a/ExtremeRagdoll/Settings.cs
+++ b/ExtremeRagdoll/Settings.cs
@@ -159,7 +159,7 @@ namespace ExtremeRagdoll
         [SettingPropertyGroup("Advanced")]
         [SettingPropertyFloatingInteger("Corpse Impulse Hard Cap (physics units)", 0f, 1_000f, "0.0",
             Order = 124, RequireRestart = false)]
-        public float CorpseImpulseHardCap { get; set; } = 12f;
+        public float CorpseImpulseHardCap { get; set; } = 60f;
 
         [SettingPropertyGroup("Advanced")]
         [SettingPropertyFloatingInteger("Corpse Launch Max Up Fraction", 0f, 1.0f, "0.00",


### PR DESCRIPTION
## Summary
- allow entity impulse routes to proceed when IsDynamicBody is unavailable instead of treating the body as static
- raise the default Corpse Impulse Hard Cap to 60 so successful ent2 impulses visibly move ragdolls
- probe TaleWorlds.Engine.ManagedExtensions.SkeletonExtensions when wiring skeleton fallbacks

## Testing
- not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68df71ef5d248320866ecf1fe43a1a32