### PR TITLE
Disable smoothing pulse and flatten missile launches

### DIFF
--- a/ExtremeRagdoll/ER_KnockbackAmplifier.cs
+++ b/ExtremeRagdoll/ER_KnockbackAmplifier.cs
@@ -516,7 +516,11 @@ namespace ExtremeRagdoll
                     }
                 }
 
-                var lethalDir = ER_DeathBlastBehavior.PrepDir(dir, missileSpeed > 0f ? 1f : 0.95f, missileSpeed > 0f ? 0f : 0.05f);
+                // Missile kills keep zero up-bias; others small
+                var lethalDir = ER_DeathBlastBehavior.PrepDir(dir,
+                                   missileSpeed > 0f ? 1f : 0.95f,
+                                   missileSpeed > 0f ? 0f : 0.02f);
+                if (missileSpeed > 0f) lethalDir.z = 0f; // hard-flat missiles
                 lethalDir = ER_DeathBlastBehavior.FinalizeImpulseDir(lethalDir);
                 blow.SwingDirection = lethalDir;
                 // ensure pending corpse-launch uses the same (flattened) direction


### PR DESCRIPTION
## Summary
- keep the third corpse-launch pulse disabled during validation to avoid reintroducing vertical launches
- hard-clamp missile ragdoll directions to planar by zeroing their Z component after PrepDir processing
- retain prior visibility improvements for impulse application failures

## Testing
- not run (per instructions)

------
https://chatgpt.com/codex/tasks/task_e_68df810384548320aa73484680d72487