### PR TITLE
Add impulse logging and neutralize lethal knockback

### DIFF
--- a/ExtremeRagdoll/ER_DeathBlast.cs
+++ b/ExtremeRagdoll/ER_DeathBlast.cs
@@ -207,6 +207,7 @@ namespace ExtremeRagdoll
         private static bool TryApplyImpulse(GameEntity ent, Skeleton skel, Vec3 impulse, Vec3 pos, int agentId = -1)
         {
             _ = agentId;
+            ER_Log.Info($"IMP_ENTER ent={(ent!=null)} skel={(skel!=null)} imp2={impulse.LengthSquared:0} pos2={pos.LengthSquared:0} id={agentId}");
             if (!ER_Math.IsFinite(in impulse) || !ER_Math.IsFinite(in pos))
                 return false;
 
@@ -222,6 +223,7 @@ namespace ExtremeRagdoll
             }
 
             bool ok = ER_ImpulseRouter.TryImpulse(ent, skel, impulse, pos);
+            if (!ok) ER_Log.Info("IMP_TRY_RETURN false");
             if (!ok && (ent != null || skel != null))
             {
                 WarmRagdoll(ent, skel);
@@ -1433,8 +1435,8 @@ namespace ExtremeRagdoll
             int pulse2Tries = Math.Max(0, (int)MathF.Round(postTries * MathF.Max(0f, ER_Config.LaunchPulse2Scale)));
             EnqueueLaunch(affected, dir, mag,                         hitPos, ER_Config.LaunchDelay1, retries: postTries);
             EnqueueLaunch(affected, dir, mag * ER_Config.LaunchPulse2Scale, hitPos, ER_Config.LaunchDelay2, retries: pulse2Tries);
-            // small smoothing pulse DISABLED for validation (can reintroduce verticals)
-            const float p3Scale = 0f;
+            // disabled for validation
+            float p3Scale = 0f;
             if (p3Scale > 0f)
                 EnqueueLaunch(affected, dir, mag * p3Scale, hitPos,
                               ER_Config.LaunchDelay2 + 0.04f,

--- a/ExtremeRagdoll/ER_ImpulseRouter.cs
+++ b/ExtremeRagdoll/ER_ImpulseRouter.cs
@@ -36,6 +36,7 @@ namespace ExtremeRagdoll
         private static float _lastImpulseLog = float.NegativeInfinity; // keep
         private static float _lastNoiseLog = float.NegativeInfinity;
         private static string _ent1Name, _ent2Name, _ent3Name, _sk1Name, _sk2Name; // debug
+        private static bool _bindLogged;
         private static float _lastAvLog = float.NegativeInfinity;
         // AV throttling state: indexes 1..5 map to routes.
         private static readonly float[] _disableUntil = new float[6];
@@ -505,6 +506,13 @@ namespace ExtremeRagdoll
             MaybeReEnable();
             // show every exception for this attempt (disable throttling)
             _lastImpulseLog = float.NegativeInfinity;
+
+            if (!_bindLogged)
+            {
+                _bindLogged = true;
+                ER_Log.Info($"IMP_BIND_NAMES ent3Inst={_ent3Inst?.Name ?? "null"} ent3={_ent3?.Name ?? "null"} ent2Inst={_ent2Inst?.Name ?? "null"} ent2={_ent2?.Name ?? "null"} sk2={_sk2?.Name ?? "null"} sk1={_sk1?.Name ?? "null"}");
+            }
+            ER_Log.Info($"IMP_TRY haveEnt={(ent!=null)} haveSk={(skel!=null)} imp2={worldImpulse.LengthSquared:0} pos2={worldPos.LengthSquared:0}");
 
             try { skel?.ActivateRagdoll(); } catch { }
             try { skel?.ForceUpdateBoneFrames(); } catch { }

--- a/ExtremeRagdoll/ER_KnockbackAmplifier.cs
+++ b/ExtremeRagdoll/ER_KnockbackAmplifier.cs
@@ -516,10 +516,11 @@ namespace ExtremeRagdoll
                     }
                 }
 
-                // Missile kills keep zero up-bias; others small
+                // Let our impulses drive it. Neutralize engine push.
                 var lethalDir = ER_DeathBlastBehavior.PrepDir(dir,
-                                   missileSpeed > 0f ? 1f : 0.95f,
-                                   missileSpeed > 0f ? 0f : 0.02f);
+                                   1f,
+                                   missileSpeed > 0f ? 0f : 0.0f);
+                blow.BaseMagnitude = 0f; // hard-zero engine KB on lethal
                 if (missileSpeed > 0f) lethalDir.z = 0f; // hard-flat missiles
                 lethalDir = ER_DeathBlastBehavior.FinalizeImpulseDir(lethalDir);
                 blow.SwingDirection = lethalDir;


### PR DESCRIPTION
## Summary
- add direct logging in TryApplyImpulse and the impulse router to prove the call path and record binding state
- neutralize lethal engine knockback (including the smoothing pulse) so custom impulses can be isolated during validation

## Testing
- not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68df8ba2fcd88320a18f2a0f91c518bb