### PR TITLE
Fix impulse router up fraction reference

### DIFF
--- a/ExtremeRagdoll/ER_ImpulseRouter.cs
+++ b/ExtremeRagdoll/ER_ImpulseRouter.cs
@@ -167,7 +167,7 @@ namespace ExtremeRagdoll
             if (l2 <= 1e-9f || float.IsNaN(l2) || float.IsInfinity(l2))
                 return new Vec3(0f, 0f, 0f);
             float len = MathF.Sqrt(l2);
-            float zMax = len * MathF.Max(0f, ER_Config.CorpseLaunchMaxUpFrac);
+            float zMax = len * MathF.Max(0f, ER_Config.CorpseLaunchMaxUpFraction);
             if (v.z > zMax)
                 v.z = zMax;
             if (v.z < 0f)
@@ -531,7 +531,7 @@ namespace ExtremeRagdoll
                 return false;
             }
             float len = MathF.Sqrt(impW.LengthSquared);
-            float zMax = len * MathF.Max(0f, ER_Config.CorpseLaunchMaxUpFrac);
+            float zMax = len * MathF.Max(0f, ER_Config.CorpseLaunchMaxUpFraction);
             if (impW.z > zMax)
                 impW.z = zMax;
             if (impW.z < 0f)


### PR DESCRIPTION
## Summary
- replace the obsolete `CorpseLaunchMaxUpFrac` access with the existing `CorpseLaunchMaxUpFraction`
- ensure the impulse router uses the same config field as the rest of the codebase to avoid compile errors

## Testing
- not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68dfa545db7c83209a51e156f9a7d7f7