### PR TITLE
Expose ragdoll helper for impulse router

### DIFF
--- a/ExtremeRagdoll/ER_DeathBlast.cs
+++ b/ExtremeRagdoll/ER_DeathBlast.cs
@@ -132,7 +132,7 @@ namespace ExtremeRagdoll
             return true;
         }
 
-        private static bool IsRagdollActiveFast(Skeleton sk)
+        internal static bool IsRagdollActiveFast(Skeleton sk)
         {
             if (sk == null)
                 return false;


### PR DESCRIPTION
## Summary
- widen the visibility of ER_DeathBlastBehavior.IsRagdollActiveFast so ER_ImpulseRouter can reuse the shared ragdoll state cache

## Testing
- not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68e0c77278808320983812819c2b7cc0