### PR TITLE
Add core import for impulse jitter

### DIFF
--- a/ExtremeRagdoll/ER_ImpulseRouter.cs
+++ b/ExtremeRagdoll/ER_ImpulseRouter.cs
@@ -2,6 +2,7 @@ using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Threading;
+using TaleWorlds.Core;
 using TaleWorlds.Engine;
 using TaleWorlds.Library;
 using TaleWorlds.MountAndBlade;
@@ -633,7 +634,6 @@ namespace ExtremeRagdoll
             catch { }
             // Allow ent2 even when engine reports BodyOwnerNone / not dynamic.
             // Agent ragdolls often flip to dynamic a frame later; skipping here kills the launch.
-            bool dynSure = true;
             // Entity impulses require a contact point; COM route remains disabled.
             // Don't return; let skeleton routes handle no-contact cases.
             if (dynOk && !haveContact)

--- a/ExtremeRagdoll/ER_KnockbackAmplifier.cs
+++ b/ExtremeRagdoll/ER_KnockbackAmplifier.cs
@@ -372,6 +372,7 @@ namespace ExtremeRagdoll
         {
             _pending.Remove(agentId);
             _lastScheduled.Remove(agentId);
+            _lastImmediateImpulse.Remove(agentId);
         }
 
         internal static bool TryMarkScheduled(int agentId, float now, float windowSec = -1f)


### PR DESCRIPTION
## Summary
- add the TaleWorlds.Core import so MBRandom resolves in the impulse router
- drop an unused variable in the impulse routing logic to silence CS0219
- clear cached immediate impulses when scheduled entries are purged

## Testing
- not run (per instructions)

------
https://chatgpt.com/codex/tasks/task_e_68e1d0eb16e8832093c04e5f66c6c2e2