### PR TITLE
Clamp synthetic contact and log ent2 deferral

### DIFF
--- a/ExtremeRagdoll/Settings.cs
+++ b/ExtremeRagdoll/Settings.cs
@@ -225,7 +225,7 @@ namespace ExtremeRagdoll
         [SettingPropertyGroup("Advanced")]
         [SettingPropertyFloatingInteger("Immediate Impulse Scale", 0f, 1f, "0.00",
             Order = 137, RequireRestart = false)]
-        public float ImmediateImpulseScale { get; set; } = 0.25f; // gentler wake-up nudge
+        public float ImmediateImpulseScale { get; set; } = 0.05f; // small wake-up nudge; avoid pre-ragdoll pushes
 
         [SettingPropertyGroup("Advanced")]
         [SettingPropertyFloatingInteger("Schedule Direction Duplicate Threshold", 0f, 4f, "0.0000",


### PR DESCRIPTION
## Summary
- gate ent2(local) impulse routing on ragdoll activation and a confirmed dynamic, sane entity
- update logging when prechecks fail before ent2 routing
- reduce the default immediate impulse scale to a gentler wake-up nudge
- clamp synthesized contacts above the entity AABB floor to prevent downward spikes
- add debug logging when ent2(local) is deferred waiting for ragdoll activation

## Testing
- Not run (per instructions)

------
https://chatgpt.com/codex/tasks/task_e_68e2304606808320ab0aca005f5ea298