### PR TITLE
Fix duplicate len declarations in impulse router

### DIFF
--- a/ExtremeRagdoll/ER_ImpulseRouter.cs
+++ b/ExtremeRagdoll/ER_ImpulseRouter.cs
@@ -837,8 +837,13 @@ namespace ExtremeRagdoll
                         float maxMag = MathF.Max(0f, ER_Config.CorpseImpulseHardCap);
                         if (maxMag > 0f)
                         {
-                            float len = impL.Length;
-                            if (len > maxMag) impL *= (maxMag / MathF.Max(len, 1e-6f));
+                            float magSq = impL.LengthSquared;
+                            float maxMagSq = maxMag * maxMag;
+                            if (magSq > maxMagSq)
+                            {
+                                float scale = maxMag / MathF.Sqrt(MathF.Max(magSq, 1e-12f));
+                                impL *= scale;
+                            }
                         }
                         if (impL.LengthSquared < ImpulseTinySqThreshold)
                             ok = false;
@@ -873,8 +878,13 @@ namespace ExtremeRagdoll
                         float maxMag = MathF.Max(0f, ER_Config.CorpseImpulseHardCap);
                         if (maxMag > 0f)
                         {
-                            float len = impL.Length;
-                            if (len > maxMag) impL *= (maxMag / MathF.Max(len, 1e-6f));
+                            float magSq = impL.LengthSquared;
+                            float maxMagSq = maxMag * maxMag;
+                            if (magSq > maxMagSq)
+                            {
+                                float scale = maxMag / MathF.Sqrt(MathF.Max(magSq, 1e-12f));
+                                impL *= scale;
+                            }
                         }
                         if (impL.LengthSquared < ImpulseTinySqThreshold)
                             ok = false;


### PR DESCRIPTION
## Summary
- prevent redeclaring `len` in nested impulse routing clamps by working with squared magnitudes

## Testing
- not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68e23771f6bc8320b6b8c51ba4472531