### PR TITLE
Use Environment.TickCount64 fallback for impulse timing

### DIFF
--- a/ExtremeRagdoll/ER_ImpulseRouter.cs
+++ b/ExtremeRagdoll/ER_ImpulseRouter.cs
@@ -1,4 +1,4 @@
-using System;
+using System; // für Environment.TickCount64
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Threading;
@@ -237,14 +237,8 @@ namespace ExtremeRagdoll
             }
             catch { }
 
-            try
-            {
-                return TimeApplication.CurrentTime;
-            }
-            catch
-            {
-                return 0f;
-            }
+            // Versionsunabhängiger Fallback (ungefähr Sekunden seit Start)
+            return (float)(Environment.TickCount64 / 1000.0);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]


### PR DESCRIPTION
## Summary
- replace the TimeApplication call with a mission/current time check and a version-agnostic Environment.TickCount64 fallback
- document the using needed for the new fallback

## Testing
- not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68e242896dbc83208d9639247ef35147