### PR TITLE
Fix Environment.TickCount fallback

### DIFF
--- a/ExtremeRagdoll/ER_ImpulseRouter.cs
+++ b/ExtremeRagdoll/ER_ImpulseRouter.cs
@@ -1,4 +1,4 @@
-using System; // für Environment.TickCount64
+using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Threading;
@@ -238,7 +238,8 @@ namespace ExtremeRagdoll
             catch { }
 
             // Versionsunabhängiger Fallback (ungefähr Sekunden seit Start)
-            return (float)(Environment.TickCount64 / 1000.0);
+            uint ms = unchecked((uint)Environment.TickCount);
+            return ms * 0.001f;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]


### PR DESCRIPTION
## Summary
- replace the Environment.TickCount64 usage with a TickCount-based fallback to support older frameworks
- keep the time fallback monotonic by casting to uint and converting to seconds

## Testing
- not run (per instructions)

------
https://chatgpt.com/codex/tasks/task_e_68e243648b0483208150c4350e4e8de8