### PR TITLE
Fix skeleton assembly shadowing in impulse router

### DIFF
--- a/ExtremeRagdoll/ER_ImpulseRouter.cs
+++ b/ExtremeRagdoll/ER_ImpulseRouter.cs
@@ -373,11 +373,11 @@ namespace ExtremeRagdoll
             }
 
             var flags = BindingFlags.Static | BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic;
-            var skAsm = typeof(Skeleton).Assembly;
+            var skeletonAsm = typeof(Skeleton).Assembly; // avoid shadowing
             foreach (var t in new[]
             {
-                skAsm.GetType("TaleWorlds.Engine.SkeletonPhysicsExtensions"),
-                skAsm.GetType("TaleWorlds.Engine.SkeletonExtensions"),
+                skeletonAsm.GetType("TaleWorlds.Engine.SkeletonPhysicsExtensions"),
+                skeletonAsm.GetType("TaleWorlds.Engine.SkeletonExtensions"),
                 typeof(Skeleton)
             })
             {


### PR DESCRIPTION
## Summary
- rename the cached Skeleton assembly variable to avoid nested shadowing

## Testing
- not run (per instructions)

------
https://chatgpt.com/codex/tasks/task_e_68e25a0f406c8320a1bbd5a02e3f3f9b