### PR TITLE
Fix skeleton fallback lookup for older runtimes

### DIFF
--- a/ExtremeRagdoll/ER_ImpulseRouter.cs
+++ b/ExtremeRagdoll/ER_ImpulseRouter.cs
@@ -403,7 +403,7 @@ namespace ExtremeRagdoll
                     foreach (var t in asm.GetTypes())
                     {
                         var n = t.FullName ?? string.Empty;
-                        if (!n.Contains("Skeleton", StringComparison.OrdinalIgnoreCase))
+                        if (string.IsNullOrEmpty(n) || n.IndexOf("Skeleton", StringComparison.OrdinalIgnoreCase) < 0)
                             continue;
                         foreach (var mi in t.GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance))
                         {


### PR DESCRIPTION
## Summary
- replace the skeleton type name filter to use IndexOf for runtimes lacking the two-argument Contains overload

## Testing
- not run (per instructions)

------
https://chatgpt.com/codex/tasks/task_e_68e2dd67edfc83208200c9aee8820683