### PR TITLE
Remove ent1 world short-circuit fallback

### DIFF
--- a/ExtremeRagdoll/ER_ImpulseRouter.cs
+++ b/ExtremeRagdoll/ER_ImpulseRouter.cs
@@ -1072,30 +1072,6 @@ namespace ExtremeRagdoll
             if (ER_Config.DebugLogging)
                 Log($"ENT3_CHECK haveContact={haveContact} dynOk={dynOk} ent3Inst={_dEnt3Inst != null || _ent3Inst != null} ent3Ext={_dEnt3 != null || _ent3 != null}");
 
-            if (!skApis && hasEnt && ER_Config.AllowEnt1WorldFallback
-                && !_ent1Unsafe && (_dEnt1 != null || _ent1 != null)
-                && (_dEnt3Inst == null && _ent3Inst == null) && (_dEnt3 == null && _ent3 == null))
-            {
-                try
-                {
-                    var impWc = impW;
-                    ClampWorldUp(ref impWc);
-                    if (impWc.LengthSquared > ImpulseTinySqThreshold)
-                    {
-                        WakeDynamicBody(ent);
-                        if (_dEnt1 != null) _dEnt1(ent, impWc);
-                        else               _ent1.Invoke(null, new object[] { ent, impWc });
-                        Log("IMPULSE_USE ext ent1(world) short-circuit (no sk APIs, no ent3)");
-                        return true;
-                    }
-                }
-                catch (Exception ex)
-                {
-                    LogFailure("ext ent1(world) short-circuit", ex);
-                    MarkUnsafe(1, ex);
-                }
-            }
-
             if (ER_Config.AllowEnt3World && haveContact && hasEnt && (dynOk || ragActive) && !_ent3Unsafe && (_dEnt3Inst != null || _ent3Inst != null))
             {
                 try


### PR DESCRIPTION
## Summary
- remove the ent1 world short-circuit path so routing falls through to the normal ent2 handling

## Testing
- not run (per instructions)

------
https://chatgpt.com/codex/tasks/task_e_68e3187bcac483209e23400068dd493f