### PR TITLE
Fix Ensure closure in impulse router

### DIFF
--- a/ExtremeRagdoll/ER_ImpulseRouter.cs
+++ b/ExtremeRagdoll/ER_ImpulseRouter.cs
@@ -1126,11 +1126,12 @@ namespace ExtremeRagdoll
                 }
 
                 Volatile.Write(ref _ensured, true);
-            }
+            } // end lock
+        } // end Ensure
 
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            private static void MaybeReEnable()
-            {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static void MaybeReEnable()
+        {
                 float now = TimeNow();
                 if (_ent1Unsafe && _disableUntil[1] <= now) _ent1Unsafe = false;
                 if (_ent2Unsafe && _disableUntil[2] <= now) _ent2Unsafe = false;
@@ -2007,8 +2008,7 @@ namespace ExtremeRagdoll
                     Log("IMPULSE_END: no entity/skeleton path succeeded");
                 return false;
             }
-    }
-    }
+        }
 
     internal static class ER_Space
     {


### PR DESCRIPTION
## Summary
- close the Ensure lock block and method so subsequent helpers are no longer nested inside it
- restore proper indentation for MaybeReEnable and keep ER_Space outside of ER_ImpulseRouter

## Testing
- not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68e44d6a96808320a13adeebbb7497c5