### PR TITLE
Queue pending ragdoll impulses until bodies go dynamic

### DIFF
--- a/ExtremeRagdoll/ER_DeathBlast.cs
+++ b/ExtremeRagdoll/ER_DeathBlast.cs
@@ -1033,6 +1033,7 @@ namespace ExtremeRagdoll
                 _missionRouterResetDone = true;
             }
             if (IsPausedFast()) return;
+            ER_ImpulseRouter.Tick();
             float now = mission.CurrentTime;
             TickCorpseQueue(now);
             // Gentle ramp after UI resume


### PR DESCRIPTION
## Summary
- add hard caps and a pending queue so ER_ImpulseRouter drip-feeds entity impulses only after ragdolls are dynamic, covering both static and instance ent2 routes
- tighten assembly enumeration to avoid noisy skeleton lookups and expose a per-frame Tick hook
- invoke ER_ImpulseRouter.Tick() from the mission behavior to flush deferred impulses each frame
- wake bodies before pending bursts dispatch and skip router ticks while the mission is paused

## Testing
- not run (per instructions)

------
https://chatgpt.com/codex/tasks/task_e_68e455b176848320bc2b2f4344fcfb14