### PR TITLE
Preserve death animations before applying ragdoll impulse

### DIFF
--- a/ExtremeRagdoll/ER_SafeDeathPipeline.cs
+++ b/ExtremeRagdoll/ER_SafeDeathPipeline.cs
@@ -92,7 +92,8 @@ namespace ExtremeRagdoll
             if (!float.IsNaN(hardCap) && !float.IsInfinity(hardCap) && hardCap > 0f && impulse > hardCap)
                 impulse = hardCap;
 
-            const float AbsoluteSafeCap = 1.25f;
+            // A single capped impulse remains visible without recreating the old multi-pulse launch/tunnelling path.
+            const float AbsoluteSafeCap = 6.0f;
             if (impulse > AbsoluteSafeCap)
                 impulse = AbsoluteSafeCap;
 

--- a/ExtremeRagdoll/ER_SafeDeathPipeline.cs
+++ b/ExtremeRagdoll/ER_SafeDeathPipeline.cs
@@ -1,0 +1,505 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using HarmonyLib;
+using TaleWorlds.Core;
+using TaleWorlds.Engine;
+using TaleWorlds.Library;
+using TaleWorlds.MountAndBlade;
+
+namespace ExtremeRagdoll
+{
+    internal static class ER_SafeDeathPipeline
+    {
+        private const string LegacyPatchId = "extremeragdoll.patch";
+
+        internal static void DisableLegacyDeathOverrides(Harmony harmony)
+        {
+            if (harmony == null)
+                return;
+
+            int removed = 0;
+            removed += UnpatchAgentMethods(harmony, typeof(ER_Amplify_RegisterBlowPatch), "Prefix", nameof(Agent.RegisterBlow));
+            removed += UnpatchAgentMethods(harmony, typeof(ER_Amplify_RegisterBlowPatch), "Postfix", nameof(Agent.RegisterBlow));
+            removed += UnpatchAgentMethods(harmony, typeof(ER_Probe_MakeDead), "Pre", nameof(Agent.MakeDead));
+            removed += UnpatchAgentMethods(harmony, typeof(ER_Probe_MakeDead), "Post", nameof(Agent.MakeDead));
+            removed += UnpatchAgentMethods(harmony, typeof(ER_Probe_Die), "Pre", "Die");
+            removed += UnpatchAgentMethods(harmony, typeof(ER_Probe_Die), "Post", "Die");
+
+            ER_Log.Info($"Safe death pipeline enabled: removed {removed} legacy death override patch(es) from {LegacyPatchId}");
+        }
+
+        private static int UnpatchAgentMethods(Harmony harmony, Type patchType, string patchMethodName, string originalMethodName)
+        {
+            MethodInfo patch = AccessTools.Method(patchType, patchMethodName);
+            if (patch == null)
+            {
+                ER_Log.Error($"Safe death pipeline: patch method not found: {patchType?.FullName}.{patchMethodName}");
+                return 0;
+            }
+
+            int removed = 0;
+            foreach (MethodInfo original in AccessTools.GetDeclaredMethods(typeof(Agent)))
+            {
+                if (original == null || original.Name != originalMethodName)
+                    continue;
+
+                try
+                {
+                    harmony.Unpatch(original, patch);
+                    removed++;
+                }
+                catch (Exception ex)
+                {
+                    ER_Log.Error($"Safe death pipeline: failed to unpatch {patchType.Name}.{patchMethodName} from {original}", ex);
+                }
+            }
+            return removed;
+        }
+
+        internal static float ComputeImpulseMagnitude(in Blow blow)
+        {
+            float baseMagnitude = blow.BaseMagnitude;
+            if (float.IsNaN(baseMagnitude) || float.IsInfinity(baseMagnitude) || baseMagnitude < 0f)
+                baseMagnitude = 0f;
+
+            float damage = blow.InflictedDamage;
+            if (float.IsNaN(damage) || float.IsInfinity(damage) || damage < 0f)
+                damage = 0f;
+
+            // Use the real fatal blow only as an input signal. The engine blow itself remains untouched.
+            // This range is strong enough to move an active ragdoll while staying below tunnelling speeds.
+            float sourceMagnitude = MathF.Max(MathF.Min(baseMagnitude, 1200f), 250f + damage * 8f);
+            float multiplier = MathF.Max(0f, ER_Config.ExtraForceMultiplier) * MathF.Max(1f, ER_Config.KnockbackMultiplier);
+            float impulse = sourceMagnitude * 1.0e-3f * multiplier;
+
+            float minimum = ER_Config.CorpseImpulseMinimum;
+            if (float.IsNaN(minimum) || float.IsInfinity(minimum) || minimum < 0f)
+                minimum = 0f;
+
+            float maximum = ER_Config.CorpseImpulseMaximum;
+            if (float.IsNaN(maximum) || float.IsInfinity(maximum) || maximum < 0f)
+                maximum = 0f;
+
+            if (maximum > 0f && minimum > maximum)
+                minimum = maximum;
+            if (minimum > 0f && impulse < minimum)
+                impulse = minimum;
+            if (maximum > 0f && impulse > maximum)
+                impulse = maximum;
+
+            float hardCap = ER_Config.CorpseImpulseHardCap;
+            if (!float.IsNaN(hardCap) && !float.IsInfinity(hardCap) && hardCap > 0f && impulse > hardCap)
+                impulse = hardCap;
+
+            const float AbsoluteSafeCap = 1.25f;
+            if (impulse > AbsoluteSafeCap)
+                impulse = AbsoluteSafeCap;
+
+            return float.IsNaN(impulse) || float.IsInfinity(impulse) || impulse <= 0f ? 0f : impulse;
+        }
+
+        internal static Vec3 ResolveDirection(Agent agent, in Blow blow)
+        {
+            Vec3 direction = blow.SwingDirection;
+            if (!ER_Math.IsFinite(in direction) || direction.LengthSquared < ER_Math.DirectionTinySq)
+            {
+                try { direction = agent.Position - blow.GlobalPosition; }
+                catch { direction = Vec3.Zero; }
+            }
+            if (!ER_Math.IsFinite(in direction) || direction.LengthSquared < ER_Math.DirectionTinySq)
+            {
+                try { direction = agent.LookDirection; }
+                catch { direction = new Vec3(0f, 1f, 0f); }
+            }
+
+            direction = ER_DeathBlastBehavior.PrepDir(direction, 0.98f, 0.02f);
+            direction = ER_DeathBlastBehavior.FinalizeImpulseDir(direction, ER_Config.CorpseLaunchMaxUpFraction);
+            if (!ER_Math.IsFinite(in direction) || direction.LengthSquared < ER_Math.DirectionTinySq)
+                return new Vec3(0f, 1f, 0f);
+            return direction;
+        }
+
+        internal static Vec3 ResolveContact(Agent agent)
+        {
+            Vec3 contact;
+            try { contact = agent.Position; }
+            catch { contact = Vec3.Zero; }
+            contact.z += 0.9f;
+            return contact;
+        }
+    }
+
+    [HarmonyPatch]
+    internal static class ER_SafeRegisterBlowCapturePatch
+    {
+        internal struct CaptureState
+        {
+            internal bool Candidate;
+            internal Vec3 Direction;
+            internal Vec3 Contact;
+            internal float ImpulseMagnitude;
+            internal float Time;
+        }
+
+        [HarmonyTargetMethods]
+        private static IEnumerable<MethodBase> TargetMethods()
+        {
+            Type blowType = typeof(Blow);
+            foreach (MethodInfo candidate in AccessTools.GetDeclaredMethods(typeof(Agent)))
+            {
+                if (candidate == null || candidate.Name != nameof(Agent.RegisterBlow))
+                    continue;
+                ParameterInfo[] parameters = candidate.GetParameters();
+                if (parameters.Length == 0)
+                    continue;
+                Type first = parameters[0].ParameterType;
+                if (first == blowType || (first.IsByRef && first.GetElementType() == blowType))
+                    yield return candidate;
+            }
+        }
+
+        [HarmonyPrefix]
+        [HarmonyPriority(Priority.First)]
+        private static void Prefix(Agent __instance, [HarmonyArgument(0)] ref Blow blow, out CaptureState __state)
+        {
+            __state = default;
+            if (__instance == null)
+                return;
+
+            float health;
+            try { health = __instance.Health; }
+            catch { return; }
+            if (float.IsNaN(health) || float.IsInfinity(health))
+                return;
+
+            float damage = blow.InflictedDamage;
+            if (float.IsNaN(damage) || float.IsInfinity(damage) || damage <= 0f)
+                return;
+
+            // Capture only a blow that can actually be fatal. The postfix confirms the final engine result.
+            if (health > 0f && health - damage > 0f)
+                return;
+
+            float impulse = ER_SafeDeathPipeline.ComputeImpulseMagnitude(in blow);
+            if (impulse <= 0f)
+                return;
+
+            __state = new CaptureState
+            {
+                Candidate = true,
+                Direction = ER_SafeDeathPipeline.ResolveDirection(__instance, in blow),
+                Contact = ER_SafeDeathPipeline.ResolveContact(__instance),
+                ImpulseMagnitude = impulse,
+                Time = __instance.Mission?.CurrentTime ?? Mission.Current?.CurrentTime ?? 0f,
+            };
+        }
+
+        [HarmonyPostfix]
+        [HarmonyPriority(Priority.Last)]
+        private static void Postfix(Agent __instance, CaptureState __state)
+        {
+            if (!__state.Candidate || __instance == null)
+                return;
+
+            float health;
+            try { health = __instance.Health; }
+            catch { return; }
+            if (float.IsNaN(health) || float.IsInfinity(health) || health > 0f)
+                return;
+
+            ER_SafeRagdollBehavior.Enqueue(
+                __instance,
+                __state.Direction,
+                __state.Contact,
+                __state.ImpulseMagnitude,
+                __state.Time,
+                "RegisterBlow");
+        }
+    }
+
+    // These legacy paths activate physics before Bannerlord has completed its death transition.
+    // Returning false leaves the engine animation/state machine in sole control of that transition.
+    [HarmonyPatch]
+    internal static class ER_DisableLegacyPreDeathQueuePatch
+    {
+        [HarmonyTargetMethods]
+        private static IEnumerable<MethodBase> TargetMethods()
+        {
+            foreach (MethodInfo method in AccessTools.GetDeclaredMethods(typeof(ER_DeathBlastBehavior)))
+                if (method != null && method.Name == "QueuePreDeath")
+                    yield return method;
+        }
+
+        [HarmonyPrefix]
+        private static bool Prefix() => false;
+    }
+
+    [HarmonyPatch]
+    internal static class ER_DisableLegacyDeadSweepPatch
+    {
+        [HarmonyTargetMethods]
+        private static IEnumerable<MethodBase> TargetMethods()
+        {
+            foreach (MethodInfo method in AccessTools.GetDeclaredMethods(typeof(ER_DeathBlastBehavior)))
+                if (method != null && method.Name == "SweepDeadRagdolls")
+                    yield return method;
+        }
+
+        [HarmonyPrefix]
+        private static bool Prefix() => false;
+    }
+
+    [HarmonyPatch]
+    internal static class ER_DisableLegacyRemovedLaunchPatch
+    {
+        [HarmonyTargetMethod]
+        private static MethodBase TargetMethod() => AccessTools.Method(typeof(ER_DeathBlastBehavior), nameof(ER_DeathBlastBehavior.OnAgentRemoved));
+
+        [HarmonyPrefix]
+        private static bool Prefix() => false;
+    }
+
+    public sealed class ER_SafeRagdollBehavior : MissionBehavior
+    {
+        private const float SolverSettleDelay = 0.033f;
+        private const float RetryDelay = 0.05f;
+        private const float PendingLifetime = 8.0f;
+        private const int MaxApplyAttempts = 8;
+
+        private sealed class PendingDeath
+        {
+            internal Agent Agent;
+            internal int AgentIndex;
+            internal Vec3 Direction;
+            internal Vec3 Contact;
+            internal float ImpulseMagnitude;
+            internal float CapturedAt;
+            internal float RagdollSeenAt = -1f;
+            internal float NextTryAt;
+            internal int Attempts;
+            internal string Source;
+        }
+
+        private static ER_SafeRagdollBehavior _instance;
+        private readonly object _gate = new object();
+        private readonly List<PendingDeath> _pending = new List<PendingDeath>(64);
+        private readonly HashSet<Agent> _completed = new HashSet<Agent>();
+
+        internal static void Reset()
+        {
+            _instance = null;
+        }
+
+        internal static void Enqueue(Agent agent, Vec3 direction, Vec3 contact, float impulseMagnitude, float capturedAt, string source)
+        {
+            _instance?.EnqueueInternal(agent, direction, contact, impulseMagnitude, capturedAt, source);
+        }
+
+        public override void OnBehaviorInitialize()
+        {
+            _instance = this;
+            lock (_gate)
+            {
+                _pending.Clear();
+                _completed.Clear();
+            }
+        }
+
+        public override void OnRemoveBehavior()
+        {
+            lock (_gate)
+            {
+                _pending.Clear();
+                _completed.Clear();
+            }
+            if (ReferenceEquals(_instance, this))
+                _instance = null;
+        }
+
+        private void EnqueueInternal(Agent agent, Vec3 direction, Vec3 contact, float impulseMagnitude, float capturedAt, string source)
+        {
+            if (agent == null || impulseMagnitude <= 0f || !ER_Math.IsFinite(in direction) || !ER_Math.IsFinite(in contact))
+                return;
+
+            int agentIndex;
+            try { agentIndex = agent.Index; }
+            catch { agentIndex = -1; }
+
+            lock (_gate)
+            {
+                if (_completed.Contains(agent))
+                    return;
+
+                for (int i = 0; i < _pending.Count; i++)
+                {
+                    PendingDeath existing = _pending[i];
+                    if (!ReferenceEquals(existing.Agent, agent))
+                        continue;
+
+                    // Retain the strongest observed fatal hit without creating stacked pulses.
+                    if (impulseMagnitude > existing.ImpulseMagnitude)
+                    {
+                        existing.Direction = direction;
+                        existing.Contact = contact;
+                        existing.ImpulseMagnitude = impulseMagnitude;
+                        existing.Source = source;
+                    }
+                    return;
+                }
+
+                _pending.Add(new PendingDeath
+                {
+                    Agent = agent,
+                    AgentIndex = agentIndex,
+                    Direction = direction,
+                    Contact = contact,
+                    ImpulseMagnitude = impulseMagnitude,
+                    CapturedAt = capturedAt,
+                    NextTryAt = capturedAt,
+                    Source = source ?? "unknown",
+                });
+            }
+        }
+
+        public override void OnAgentRemoved(Agent affected, Agent affector, AgentState state, KillingBlow killingBlow)
+        {
+            if (affected == null || state != AgentState.Killed)
+                return;
+
+            lock (_gate)
+            {
+                if (_completed.Contains(affected))
+                    return;
+                for (int i = 0; i < _pending.Count; i++)
+                    if (ReferenceEquals(_pending[i].Agent, affected))
+                        return;
+            }
+
+            // Scripted deaths may bypass RegisterBlow. Queue a conservative fallback and still wait for real ragdoll state.
+            Vec3 direction;
+            try { direction = affected.LookDirection; }
+            catch { direction = new Vec3(0f, 1f, 0f); }
+            direction = ER_DeathBlastBehavior.FinalizeImpulseDir(
+                ER_DeathBlastBehavior.PrepDir(direction, 0.98f, 0.02f),
+                ER_Config.CorpseLaunchMaxUpFraction);
+
+            float fallbackImpulse = 0.60f * MathF.Max(1f, ER_Config.KnockbackMultiplier);
+            float hardCap = ER_Config.CorpseImpulseHardCap;
+            if (hardCap > 0f && fallbackImpulse > hardCap)
+                fallbackImpulse = hardCap;
+            if (fallbackImpulse > 1.25f)
+                fallbackImpulse = 1.25f;
+
+            float now = Mission?.CurrentTime ?? affected.Mission?.CurrentTime ?? 0f;
+            EnqueueInternal(affected, direction, ER_SafeDeathPipeline.ResolveContact(affected), fallbackImpulse, now, "OnAgentRemoved");
+        }
+
+        public override void OnMissionTick(float dt)
+        {
+            if (dt <= 0f || Mission == null || MBCommon.IsPaused)
+                return;
+
+            float now = Mission.CurrentTime;
+            lock (_gate)
+            {
+                for (int i = _pending.Count - 1; i >= 0; i--)
+                {
+                    PendingDeath pending = _pending[i];
+                    Agent agent = pending.Agent;
+                    if (agent == null || now - pending.CapturedAt > PendingLifetime)
+                    {
+                        _pending.RemoveAt(i);
+                        continue;
+                    }
+                    if (now < pending.NextTryAt)
+                        continue;
+
+                    float health;
+                    try { health = agent.Health; }
+                    catch
+                    {
+                        _pending.RemoveAt(i);
+                        continue;
+                    }
+                    if (float.IsNaN(health) || float.IsInfinity(health) || health > 0f)
+                        continue;
+
+                    GameEntity entity = null;
+                    Skeleton skeleton = null;
+                    try { entity = agent.AgentVisuals?.GetEntity(); } catch { entity = null; }
+                    try { skeleton = agent.AgentVisuals?.GetSkeleton(); } catch { skeleton = null; }
+                    if (skeleton == null)
+                    {
+                        pending.NextTryAt = now + RetryDelay;
+                        continue;
+                    }
+
+                    bool ragdollActive;
+                    try { ragdollActive = ER_DeathBlastBehavior.IsRagdollActiveFast(skeleton); }
+                    catch { ragdollActive = false; }
+                    if (!ragdollActive)
+                    {
+                        // No activation, animation ticking, synthetic blow, or wake call here.
+                        // Bannerlord owns the complete death-animation-to-ragdoll transition.
+                        pending.NextTryAt = now + RetryDelay;
+                        continue;
+                    }
+
+                    if (pending.RagdollSeenAt < 0f)
+                    {
+                        pending.RagdollSeenAt = now;
+                        pending.NextTryAt = now + SolverSettleDelay;
+                        continue;
+                    }
+                    if (now - pending.RagdollSeenAt < SolverSettleDelay)
+                        continue;
+
+                    Vec3 contact = ER_DeathBlastBehavior.ClampHitToBody(agent, pending.Contact);
+                    Vec3 impulse = pending.Direction * pending.ImpulseMagnitude;
+                    if (impulse.z < 0f)
+                        impulse.z = 0f;
+
+                    bool applied = false;
+                    try
+                    {
+                        applied = ER_DeathBlastBehavior.TryImpulseDirect(
+                            entity,
+                            skeleton,
+                            in impulse,
+                            in contact,
+                            pending.AgentIndex,
+                            now);
+                    }
+                    catch
+                    {
+                        applied = false;
+                    }
+
+                    if (applied)
+                    {
+                        _completed.Add(agent);
+                        _pending.RemoveAt(i);
+                        if (ER_Config.DebugLogging)
+                            ER_Log.Info($"Safe corpse impulse applied Agent#{pending.AgentIndex} source={pending.Source} impulse={pending.ImpulseMagnitude:0.00}");
+                        continue;
+                    }
+
+                    pending.Attempts++;
+                    if (pending.Attempts >= MaxApplyAttempts)
+                    {
+                        _pending.RemoveAt(i);
+                        if (ER_Config.DebugLogging)
+                            ER_Log.Info($"Safe corpse impulse dropped Agent#{pending.AgentIndex}: active ragdoll rejected {pending.Attempts} attempt(s)");
+                    }
+                    else
+                    {
+                        pending.NextTryAt = now + RetryDelay;
+                    }
+                }
+            }
+        }
+
+        public override MissionBehaviorType BehaviorType => MissionBehaviorType.Other;
+    }
+}

--- a/ExtremeRagdoll/ER_SafeDeathPipeline.cs
+++ b/ExtremeRagdoll/ER_SafeDeathPipeline.cs
@@ -464,13 +464,11 @@ namespace ExtremeRagdoll
                     bool applied = false;
                     try
                     {
-                        applied = ER_DeathBlastBehavior.TryImpulseDirect(
+                        applied = ER_ActiveRagdollImpulse.TryApply(
                             entity,
                             skeleton,
                             in impulse,
-                            in contact,
-                            pending.AgentIndex,
-                            now);
+                            in contact);
                     }
                     catch
                     {

--- a/ExtremeRagdoll/ER_SafeImpulseBridge.cs
+++ b/ExtremeRagdoll/ER_SafeImpulseBridge.cs
@@ -146,52 +146,6 @@ namespace ExtremeRagdoll
         }
     }
 
-    internal static class ER_SafeImpulseScope
-    {
-        [ThreadStatic]
-        internal static int Depth;
-    }
-
-    [HarmonyPatch(typeof(ER_SafeRagdollBehavior), nameof(ER_SafeRagdollBehavior.OnMissionTick))]
-    internal static class ER_SafeImpulseScopePatch
-    {
-        [HarmonyPrefix]
-        [HarmonyPriority(Priority.First)]
-        private static void Prefix(out int __state)
-        {
-            __state = ER_SafeImpulseScope.Depth;
-            ER_SafeImpulseScope.Depth = __state + 1;
-        }
-
-        [HarmonyFinalizer]
-        [HarmonyPriority(Priority.Last)]
-        private static Exception Finalizer(int __state, Exception __exception)
-        {
-            ER_SafeImpulseScope.Depth = __state;
-            return __exception;
-        }
-    }
-
-    [HarmonyPatch(typeof(ER_DeathBlastBehavior), "TryImpulseDirect")]
-    internal static class ER_SafeImpulseBridgePatch
-    {
-        [HarmonyPrefix]
-        [HarmonyPriority(Priority.First)]
-        private static bool Prefix(
-            GameEntity ent,
-            Skeleton skel,
-            ref Vec3 worldImpulse,
-            ref Vec3 worldPos,
-            ref bool __result)
-        {
-            if (ER_SafeImpulseScope.Depth <= 0)
-                return true;
-
-            __result = ER_ActiveRagdollImpulse.TryApply(ent, skel, in worldImpulse, in worldPos);
-            return false;
-        }
-    }
-
     /// <summary>
     /// Applies one impulse to a body that Bannerlord has already converted to ragdoll.
     /// No route in this class activates, wakes, ticks, freezes, or otherwise changes ragdoll state.

--- a/ExtremeRagdoll/ER_SafeImpulseBridge.cs
+++ b/ExtremeRagdoll/ER_SafeImpulseBridge.cs
@@ -1,0 +1,213 @@
+using System;
+using System.Reflection;
+using System.Threading;
+using HarmonyLib;
+using TaleWorlds.Engine;
+using TaleWorlds.Library;
+
+namespace ExtremeRagdoll
+{
+    internal static class ER_SafeImpulseScope
+    {
+        [ThreadStatic]
+        internal static int Depth;
+    }
+
+    [HarmonyPatch(typeof(ER_SafeRagdollBehavior), nameof(ER_SafeRagdollBehavior.OnMissionTick))]
+    internal static class ER_SafeImpulseScopePatch
+    {
+        [HarmonyPrefix]
+        [HarmonyPriority(Priority.First)]
+        private static void Prefix(out int __state)
+        {
+            __state = ER_SafeImpulseScope.Depth;
+            ER_SafeImpulseScope.Depth = __state + 1;
+        }
+
+        [HarmonyFinalizer]
+        [HarmonyPriority(Priority.Last)]
+        private static Exception Finalizer(int __state, Exception __exception)
+        {
+            ER_SafeImpulseScope.Depth = __state;
+            return __exception;
+        }
+    }
+
+    [HarmonyPatch(typeof(ER_DeathBlastBehavior), "TryImpulseDirect")]
+    internal static class ER_SafeImpulseBridgePatch
+    {
+        [HarmonyPrefix]
+        [HarmonyPriority(Priority.First)]
+        private static bool Prefix(
+            GameEntity ent,
+            Skeleton skel,
+            ref Vec3 worldImpulse,
+            ref Vec3 worldPos,
+            ref bool __result)
+        {
+            if (ER_SafeImpulseScope.Depth <= 0)
+                return true;
+
+            __result = ER_ActiveRagdollImpulse.TryApply(ent, skel, in worldImpulse, in worldPos);
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Applies one world-space impulse to a body that Bannerlord has already converted to ragdoll.
+    /// This class deliberately has no activation, wake-up, animation-tick, synthetic-blow, or retry logic.
+    /// </summary>
+    internal static class ER_ActiveRagdollImpulse
+    {
+        private static readonly object BindLock = new object();
+        private static int _bound;
+        private static Action<GameEntity, Vec3, Vec3, bool> _instanceApplyWorld;
+        private static Action<GameEntity, Vec3, Vec3, bool> _extensionApplyWorld;
+        private static MethodInfo _instanceApplyWorldMethod;
+        private static MethodInfo _extensionApplyWorldMethod;
+        private static int _missingRouteLogged;
+
+        internal static bool TryApply(GameEntity entity, Skeleton skeleton, in Vec3 worldImpulse, in Vec3 worldPosition)
+        {
+            if (entity == null || skeleton == null)
+                return false;
+            if (!ER_Math.IsFinite(in worldImpulse) || !ER_Math.IsFinite(in worldPosition))
+                return false;
+            if (worldImpulse.LengthSquared < ER_Math.ImpulseTinySq)
+                return false;
+
+            bool ragdollActive;
+            try { ragdollActive = ER_DeathBlastBehavior.IsRagdollActiveFast(skeleton); }
+            catch { ragdollActive = false; }
+            if (!ragdollActive)
+                return false;
+
+            bool hasPhysicsBody;
+            try { hasPhysicsBody = entity.HasPhysicsBody(); }
+            catch { hasPhysicsBody = false; }
+            if (!hasPhysicsBody)
+                return false;
+
+            Vec3 min;
+            Vec3 max;
+            try
+            {
+                min = entity.GetPhysicsBoundingBoxMin();
+                max = entity.GetPhysicsBoundingBoxMax();
+            }
+            catch
+            {
+                return false;
+            }
+            if (!ER_Math.IsFinite(in min) || !ER_Math.IsFinite(in max))
+                return false;
+            Vec3 extent = max - min;
+            if (!ER_Math.IsFinite(in extent) || extent.x <= 0f || extent.y <= 0f || extent.z <= 0f)
+                return false;
+            float maxExtent = ER_Config.MaxAabbExtent;
+            if (extent.x > maxExtent || extent.y > maxExtent || extent.z > maxExtent)
+                return false;
+
+            EnsureBound();
+
+            try
+            {
+                if (_instanceApplyWorld != null)
+                {
+                    _instanceApplyWorld(entity, worldImpulse, worldPosition, false);
+                    return true;
+                }
+                if (_instanceApplyWorldMethod != null)
+                {
+                    _instanceApplyWorldMethod.Invoke(entity, new object[] { worldImpulse, worldPosition, false });
+                    return true;
+                }
+                if (_extensionApplyWorld != null)
+                {
+                    _extensionApplyWorld(entity, worldImpulse, worldPosition, false);
+                    return true;
+                }
+                if (_extensionApplyWorldMethod != null)
+                {
+                    _extensionApplyWorldMethod.Invoke(null, new object[] { entity, worldImpulse, worldPosition, false });
+                    return true;
+                }
+            }
+            catch (TargetInvocationException ex)
+            {
+                Exception inner = ex.InnerException ?? ex;
+                if (ER_Config.DebugLogging)
+                    ER_Log.Error("Safe active-ragdoll impulse failed", inner);
+                return false;
+            }
+            catch (Exception ex)
+            {
+                if (ER_Config.DebugLogging)
+                    ER_Log.Error("Safe active-ragdoll impulse failed", ex);
+                return false;
+            }
+
+            if (Interlocked.Exchange(ref _missingRouteLogged, 1) == 0)
+                ER_Log.Error("Safe active-ragdoll impulse disabled: no world-space GameEntity impulse API was found");
+            return false;
+        }
+
+        private static void EnsureBound()
+        {
+            if (Volatile.Read(ref _bound) != 0)
+                return;
+
+            lock (BindLock)
+            {
+                if (_bound != 0)
+                    return;
+
+                const BindingFlags InstanceFlags = BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic;
+                _instanceApplyWorldMethod = typeof(GameEntity).GetMethod(
+                    "ApplyImpulseToDynamicBody",
+                    InstanceFlags,
+                    null,
+                    new[] { typeof(Vec3), typeof(Vec3), typeof(bool) },
+                    null);
+                if (_instanceApplyWorldMethod != null)
+                {
+                    try
+                    {
+                        _instanceApplyWorld = (Action<GameEntity, Vec3, Vec3, bool>)_instanceApplyWorldMethod.CreateDelegate(
+                            typeof(Action<GameEntity, Vec3, Vec3, bool>));
+                    }
+                    catch
+                    {
+                        _instanceApplyWorld = null;
+                    }
+                }
+
+                Type extensions = typeof(GameEntity).Assembly.GetType("TaleWorlds.Engine.GameEntityPhysicsExtensions");
+                if (extensions != null)
+                {
+                    const BindingFlags StaticFlags = BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic;
+                    _extensionApplyWorldMethod = extensions.GetMethod(
+                        "ApplyImpulseToDynamicBody",
+                        StaticFlags,
+                        null,
+                        new[] { typeof(GameEntity), typeof(Vec3), typeof(Vec3), typeof(bool) },
+                        null);
+                    if (_extensionApplyWorldMethod != null)
+                    {
+                        try
+                        {
+                            _extensionApplyWorld = (Action<GameEntity, Vec3, Vec3, bool>)_extensionApplyWorldMethod.CreateDelegate(
+                                typeof(Action<GameEntity, Vec3, Vec3, bool>));
+                        }
+                        catch
+                        {
+                            _extensionApplyWorld = null;
+                        }
+                    }
+                }
+
+                Volatile.Write(ref _bound, 1);
+            }
+        }
+    }
+}

--- a/ExtremeRagdoll/ER_SafeImpulseBridge.cs
+++ b/ExtremeRagdoll/ER_SafeImpulseBridge.cs
@@ -1,12 +1,122 @@
 using System;
+using System.Collections.Generic;
 using System.Reflection;
 using System.Threading;
 using HarmonyLib;
+using TaleWorlds.Core;
 using TaleWorlds.Engine;
 using TaleWorlds.Library;
+using TaleWorlds.MountAndBlade;
 
 namespace ExtremeRagdoll
 {
+    internal static class ER_SafeLegacyRegisterBlow
+    {
+        internal static void RestoreNonLethalPrefix(Harmony harmony)
+        {
+            if (harmony == null)
+                return;
+
+            MethodInfo legacyPrefix = AccessTools.Method(typeof(ER_Amplify_RegisterBlowPatch), "Prefix");
+            if (legacyPrefix == null)
+            {
+                ER_Log.Error("Safe death pipeline: legacy RegisterBlow prefix was not found");
+                return;
+            }
+
+            int restored = 0;
+            Type blowType = typeof(Blow);
+            foreach (MethodInfo original in AccessTools.GetDeclaredMethods(typeof(Agent)))
+            {
+                if (original == null || original.Name != nameof(Agent.RegisterBlow))
+                    continue;
+                ParameterInfo[] parameters = original.GetParameters();
+                if (parameters.Length == 0)
+                    continue;
+                Type first = parameters[0].ParameterType;
+                if (first != blowType && !(first.IsByRef && first.GetElementType() == blowType))
+                    continue;
+
+                try
+                {
+                    var patch = new HarmonyMethod(legacyPrefix)
+                    {
+                        priority = Priority.Last,
+                        after = new[] { "TOR", "TOR_Core" },
+                    };
+                    harmony.Patch(original, prefix: patch);
+                    restored++;
+                }
+                catch (Exception ex)
+                {
+                    ER_Log.Error($"Safe death pipeline: failed to restore nonlethal RegisterBlow prefix on {original}", ex);
+                }
+            }
+
+            ER_Log.Info($"Safe death pipeline: restored nonlethal RegisterBlow prefix on {restored} overload(s)");
+        }
+    }
+
+    /// <summary>
+    /// Keeps the original knockback amplifier for living targets while preventing it from touching a lethal blow.
+    /// The scope remains active until Harmony finalizers run, covering the old late-priority prefix.
+    /// </summary>
+    [HarmonyPatch]
+    internal static class ER_SuppressLegacyLethalRegisterBlowPatch
+    {
+        [HarmonyTargetMethods]
+        private static IEnumerable<MethodBase> TargetMethods()
+        {
+            Type blowType = typeof(Blow);
+            foreach (MethodInfo candidate in AccessTools.GetDeclaredMethods(typeof(Agent)))
+            {
+                if (candidate == null || candidate.Name != nameof(Agent.RegisterBlow))
+                    continue;
+                ParameterInfo[] parameters = candidate.GetParameters();
+                if (parameters.Length == 0)
+                    continue;
+                Type first = parameters[0].ParameterType;
+                if (first == blowType || (first.IsByRef && first.GetElementType() == blowType))
+                    yield return candidate;
+            }
+        }
+
+        [HarmonyPrefix]
+        [HarmonyPriority(Priority.First)]
+        private static void Prefix(
+            Agent __instance,
+            [HarmonyArgument(0)] ref Blow blow,
+            out IDisposable __state)
+        {
+            __state = null;
+            if (__instance == null)
+                return;
+
+            float health;
+            try { health = __instance.Health; }
+            catch { return; }
+            if (float.IsNaN(health) || float.IsInfinity(health))
+                return;
+
+            float damage = blow.InflictedDamage;
+            if (float.IsNaN(damage) || float.IsInfinity(damage))
+                damage = 0f;
+
+            bool lethal = health <= 0f || (damage > 0f && health - damage <= 0f);
+            if (lethal)
+                __state = ER_Amplify_RegisterBlowPatch.SuppressPrefixScope();
+        }
+
+        [HarmonyFinalizer]
+        [HarmonyPriority(Priority.Last)]
+        private static Exception Finalizer(IDisposable __state, Exception __exception)
+        {
+            try { __state?.Dispose(); }
+            catch { }
+            return __exception;
+        }
+    }
+
     internal static class ER_SafeImpulseScope
     {
         [ThreadStatic]

--- a/ExtremeRagdoll/ER_SafeImpulseBridge.cs
+++ b/ExtremeRagdoll/ER_SafeImpulseBridge.cs
@@ -10,6 +10,34 @@ using TaleWorlds.MountAndBlade;
 
 namespace ExtremeRagdoll
 {
+    // The legacy evaluator caches the first enum name containing "active". Bannerlord declares
+    // ActiveFirstTick before Active, so the persistent Active state was incorrectly treated as inactive.
+    [HarmonyPatch(typeof(ER_DeathBlastBehavior), "IsRagdollActiveFast")]
+    internal static class ER_ExactRagdollStatePatch
+    {
+        [HarmonyPrefix]
+        [HarmonyPriority(Priority.First)]
+        private static bool Prefix(Skeleton sk, ref bool __result)
+        {
+            if (sk == null)
+            {
+                __result = false;
+                return false;
+            }
+
+            try
+            {
+                RagdollState state = sk.GetCurrentRagdollState();
+                __result = state == RagdollState.ActiveFirstTick || state == RagdollState.Active;
+            }
+            catch
+            {
+                __result = false;
+            }
+            return false;
+        }
+    }
+
     internal static class ER_SafeLegacyRegisterBlow
     {
         internal static void RestoreNonLethalPrefix(Harmony harmony)

--- a/ExtremeRagdoll/ER_SafeImpulseBridge.cs
+++ b/ExtremeRagdoll/ER_SafeImpulseBridge.cs
@@ -82,7 +82,8 @@ namespace ExtremeRagdoll
         }
 
         [HarmonyPrefix]
-        [HarmonyPriority(Priority.First)]
+        [HarmonyPriority(Priority.Low)]
+        [HarmonyAfter("TOR", "TOR_Core")]
         private static void Prefix(
             Agent __instance,
             [HarmonyArgument(0)] ref Blow blow,

--- a/ExtremeRagdoll/ER_SafeImpulseBridge.cs
+++ b/ExtremeRagdoll/ER_SafeImpulseBridge.cs
@@ -164,17 +164,25 @@ namespace ExtremeRagdoll
     }
 
     /// <summary>
-    /// Applies one world-space impulse to a body that Bannerlord has already converted to ragdoll.
-    /// This class deliberately has no activation, wake-up, animation-tick, synthetic-blow, or retry logic.
+    /// Applies one impulse to a body that Bannerlord has already converted to ragdoll.
+    /// No route in this class activates, wakes, ticks, freezes, or otherwise changes ragdoll state.
     /// </summary>
     internal static class ER_ActiveRagdollImpulse
     {
         private static readonly object BindLock = new object();
         private static int _bound;
-        private static Action<GameEntity, Vec3, Vec3, bool> _instanceApplyWorld;
-        private static Action<GameEntity, Vec3, Vec3, bool> _extensionApplyWorld;
-        private static MethodInfo _instanceApplyWorldMethod;
-        private static MethodInfo _extensionApplyWorldMethod;
+
+        // Bannerlord 1.3.x: local contact + global force + ForceMode.Impulse.
+        private static MethodInfo _globalForceAtLocalPos;
+        private static object _impulseForceMode;
+
+        // Compatibility routes used by older/newer engine builds.
+        private static MethodInfo _worldImpulseInstance3;
+        private static MethodInfo _worldImpulseExtension4;
+        private static MethodInfo _worldImpulseInstance2;
+        private static MethodInfo _localImpulseInstance2;
+        private static MethodInfo _localImpulseExtension3;
+
         private static int _missingRouteLogged;
 
         internal static bool TryApply(GameEntity entity, Skeleton skeleton, in Vec3 worldImpulse, in Vec3 worldPosition)
@@ -215,31 +223,60 @@ namespace ExtremeRagdoll
             if (!ER_Math.IsFinite(in extent) || extent.x <= 0f || extent.y <= 0f || extent.z <= 0f)
                 return false;
             float maxExtent = ER_Config.MaxAabbExtent;
+            if (float.IsNaN(maxExtent) || float.IsInfinity(maxExtent) || maxExtent <= 0f)
+                maxExtent = 1024f;
             if (extent.x > maxExtent || extent.y > maxExtent || extent.z > maxExtent)
+                return false;
+
+            MatrixFrame frame;
+            try { frame = entity.GetGlobalFrame(); }
+            catch { return false; }
+
+            Vec3 localPosition = WorldPointToLocal(in frame, in worldPosition);
+            Vec3 localImpulse = WorldVectorToLocal(in frame, in worldImpulse);
+            if (!ER_Math.IsFinite(in localPosition) || !ER_Math.IsFinite(in localImpulse))
                 return false;
 
             EnsureBound();
 
             try
             {
-                if (_instanceApplyWorld != null)
+                if (_globalForceAtLocalPos != null && _impulseForceMode != null)
                 {
-                    _instanceApplyWorld(entity, worldImpulse, worldPosition, false);
+                    _globalForceAtLocalPos.Invoke(
+                        null,
+                        new[] { (object)entity, localPosition, worldImpulse, _impulseForceMode });
                     return true;
                 }
-                if (_instanceApplyWorldMethod != null)
+
+                if (_worldImpulseInstance3 != null)
                 {
-                    _instanceApplyWorldMethod.Invoke(entity, new object[] { worldImpulse, worldPosition, false });
+                    _worldImpulseInstance3.Invoke(entity, new object[] { worldImpulse, worldPosition, false });
                     return true;
                 }
-                if (_extensionApplyWorld != null)
+
+                if (_worldImpulseExtension4 != null)
                 {
-                    _extensionApplyWorld(entity, worldImpulse, worldPosition, false);
+                    _worldImpulseExtension4.Invoke(null, new object[] { entity, worldImpulse, worldPosition, false });
                     return true;
                 }
-                if (_extensionApplyWorldMethod != null)
+
+                // Legacy GameEntity API: position first, impulse second.
+                if (_worldImpulseInstance2 != null)
                 {
-                    _extensionApplyWorldMethod.Invoke(null, new object[] { entity, worldImpulse, worldPosition, false });
+                    _worldImpulseInstance2.Invoke(entity, new object[] { worldPosition, worldImpulse });
+                    return true;
+                }
+
+                if (_localImpulseInstance2 != null)
+                {
+                    _localImpulseInstance2.Invoke(entity, new object[] { localPosition, localImpulse });
+                    return true;
+                }
+
+                if (_localImpulseExtension3 != null)
+                {
+                    _localImpulseExtension3.Invoke(null, new object[] { entity, localPosition, localImpulse });
                     return true;
                 }
             }
@@ -258,8 +295,22 @@ namespace ExtremeRagdoll
             }
 
             if (Interlocked.Exchange(ref _missingRouteLogged, 1) == 0)
-                ER_Log.Error("Safe active-ragdoll impulse disabled: no world-space GameEntity impulse API was found");
+                ER_Log.Error("Safe active-ragdoll impulse disabled: no compatible GameEntity impulse API was found");
             return false;
+        }
+
+        private static Vec3 WorldPointToLocal(in MatrixFrame frame, in Vec3 worldPoint)
+        {
+            Vec3 delta = worldPoint - frame.origin;
+            return WorldVectorToLocal(in frame, in delta);
+        }
+
+        private static Vec3 WorldVectorToLocal(in MatrixFrame frame, in Vec3 worldVector)
+        {
+            return new Vec3(
+                frame.rotation.s.x * worldVector.x + frame.rotation.s.y * worldVector.y + frame.rotation.s.z * worldVector.z,
+                frame.rotation.f.x * worldVector.x + frame.rotation.f.y * worldVector.y + frame.rotation.f.z * worldVector.z,
+                frame.rotation.u.x * worldVector.x + frame.rotation.u.y * worldVector.y + frame.rotation.u.z * worldVector.z);
         }
 
         private static void EnsureBound()
@@ -273,46 +324,60 @@ namespace ExtremeRagdoll
                     return;
 
                 const BindingFlags InstanceFlags = BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic;
-                _instanceApplyWorldMethod = typeof(GameEntity).GetMethod(
+                const BindingFlags StaticFlags = BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic;
+
+                Type gameEntityType = typeof(GameEntity);
+                Type vec3Type = typeof(Vec3);
+                Type extensions = gameEntityType.Assembly.GetType("TaleWorlds.Engine.GameEntityPhysicsExtensions");
+
+                _worldImpulseInstance3 = gameEntityType.GetMethod(
                     "ApplyImpulseToDynamicBody",
                     InstanceFlags,
                     null,
-                    new[] { typeof(Vec3), typeof(Vec3), typeof(bool) },
+                    new[] { vec3Type, vec3Type, typeof(bool) },
                     null);
-                if (_instanceApplyWorldMethod != null)
-                {
-                    try
-                    {
-                        _instanceApplyWorld = (Action<GameEntity, Vec3, Vec3, bool>)_instanceApplyWorldMethod.CreateDelegate(
-                            typeof(Action<GameEntity, Vec3, Vec3, bool>));
-                    }
-                    catch
-                    {
-                        _instanceApplyWorld = null;
-                    }
-                }
 
-                Type extensions = typeof(GameEntity).Assembly.GetType("TaleWorlds.Engine.GameEntityPhysicsExtensions");
+                _worldImpulseInstance2 = gameEntityType.GetMethod(
+                    "ApplyImpulseToDynamicBody",
+                    InstanceFlags,
+                    null,
+                    new[] { vec3Type, vec3Type },
+                    null);
+
+                _localImpulseInstance2 = gameEntityType.GetMethod(
+                    "ApplyLocalImpulseToDynamicBody",
+                    InstanceFlags,
+                    null,
+                    new[] { vec3Type, vec3Type },
+                    null);
+
                 if (extensions != null)
                 {
-                    const BindingFlags StaticFlags = BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic;
-                    _extensionApplyWorldMethod = extensions.GetMethod(
+                    _worldImpulseExtension4 = extensions.GetMethod(
                         "ApplyImpulseToDynamicBody",
                         StaticFlags,
                         null,
-                        new[] { typeof(GameEntity), typeof(Vec3), typeof(Vec3), typeof(bool) },
+                        new[] { gameEntityType, vec3Type, vec3Type, typeof(bool) },
                         null);
-                    if (_extensionApplyWorldMethod != null)
+
+                    _localImpulseExtension3 = extensions.GetMethod(
+                        "ApplyLocalImpulseToDynamicBody",
+                        StaticFlags,
+                        null,
+                        new[] { gameEntityType, vec3Type, vec3Type },
+                        null);
+
+                    Type forceModeType = extensions.GetNestedType("ForceMode", BindingFlags.Public | BindingFlags.NonPublic);
+                    if (forceModeType != null && forceModeType.IsEnum)
                     {
-                        try
-                        {
-                            _extensionApplyWorld = (Action<GameEntity, Vec3, Vec3, bool>)_extensionApplyWorldMethod.CreateDelegate(
-                                typeof(Action<GameEntity, Vec3, Vec3, bool>));
-                        }
-                        catch
-                        {
-                            _extensionApplyWorld = null;
-                        }
+                        _globalForceAtLocalPos = extensions.GetMethod(
+                            "ApplyGlobalForceAtLocalPosToDynamicBody",
+                            StaticFlags,
+                            null,
+                            new[] { gameEntityType, vec3Type, vec3Type, forceModeType },
+                            null);
+                        if (_globalForceAtLocalPos != null)
+                            _impulseForceMode = Enum.ToObject(forceModeType, 1);
                     }
                 }
 

--- a/ExtremeRagdoll/ExtremeRagdoll.csproj
+++ b/ExtremeRagdoll/ExtremeRagdoll.csproj
@@ -114,6 +114,7 @@
     <Compile Include="ER_Log.cs" />
     <Compile Include="ER_RagdollPrep.cs" />
     <Compile Include="ER_SafeDeathPipeline.cs" />
+    <Compile Include="ER_SafeImpulseBridge.cs" />
     <Compile Include="ER_TOR_Adapter.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SubModule.cs" />

--- a/ExtremeRagdoll/ExtremeRagdoll.csproj
+++ b/ExtremeRagdoll/ExtremeRagdoll.csproj
@@ -19,7 +19,7 @@
     <!--
       Bannerlord reference path handling
       - Set BannerlordGameDir or BannerlordBinPath in your build environment.
-      - Example: msbuild /p:BannerlordGameDir="C:\Program Files (x86)\Steam\steamapps\common\Mount & Blade II Bannerlord"
+      - Example: msbuild /p:BannerlordGameDir="C:\Program Files (x86)\Steam\steamapps\common\Mount &amp; Blade II Bannerlord"
     -->
     <BannerlordGameDir Condition="'$(BannerlordGameDir)' == ''">$(BANNERLORD_GAME_DIR)</BannerlordGameDir>
     <BannerlordBinPath Condition="'$(BannerlordBinPath)' == ''">$(BANNERLORD_BIN_PATH)</BannerlordBinPath>
@@ -113,6 +113,7 @@
     <Compile Include="ER_Math.cs" />
     <Compile Include="ER_Log.cs" />
     <Compile Include="ER_RagdollPrep.cs" />
+    <Compile Include="ER_SafeDeathPipeline.cs" />
     <Compile Include="ER_TOR_Adapter.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SubModule.cs" />

--- a/ExtremeRagdoll/SubModule.cs
+++ b/ExtremeRagdoll/SubModule.cs
@@ -19,6 +19,7 @@ namespace ExtremeRagdoll
             var harmony = new Harmony("extremeragdoll.patch");
             harmony.PatchAll();
             ER_SafeDeathPipeline.DisableLegacyDeathOverrides(harmony);
+            ER_SafeLegacyRegisterBlow.RestoreNonLethalPrefix(harmony);
             _patched = true;
             ER_Log.Info("OnSubModuleLoad: PatchAll requested");
         }

--- a/ExtremeRagdoll/SubModule.cs
+++ b/ExtremeRagdoll/SubModule.cs
@@ -16,7 +16,9 @@ namespace ExtremeRagdoll
         {
             ER_Log.Info($"Debug logging enabled: writing to {ER_Log.LogFilePath}");
             if (_patched) return;
-            new Harmony("extremeragdoll.patch").PatchAll();
+            var harmony = new Harmony("extremeragdoll.patch");
+            harmony.PatchAll();
+            ER_SafeDeathPipeline.DisableLegacyDeathOverrides(harmony);
             _patched = true;
             ER_Log.Info("OnSubModuleLoad: PatchAll requested");
         }
@@ -92,7 +94,9 @@ namespace ExtremeRagdoll
         public override void OnMissionBehaviorInitialize(Mission mission)
         {
             ER_Amplify_RegisterBlowPatch.ClearPending();
+            ER_SafeRagdollBehavior.Reset();
             mission.AddMissionBehavior(new ER_DeathBlastBehavior());
+            mission.AddMissionBehavior(new ER_SafeRagdollBehavior());
             if (!_adapted)
             {
                 try
@@ -106,7 +110,7 @@ namespace ExtremeRagdoll
                 {
                 }
             }
-            ER_Log.Info("MissionBehavior added: ER_DeathBlastBehavior");
+            ER_Log.Info("Mission behaviors added: ER_DeathBlastBehavior, ER_SafeRagdollBehavior");
         }
         // No OnMissionEnded override needed; pending gets cleared on behavior removal and mission start.
     }


### PR DESCRIPTION
## Root cause

The lethal-hit path was taking ownership of Bannerlord's death transition before the engine had completed it:

- `RegisterBlow` force-activated ragdoll before the original lethal blow was processed.
- The fatal `Blow` was rewritten and a synthetic zero-damage knockdown blow was injected.
- `MakeDead`, `Die`, the `RegisterBlow` postfix, and the periodic dead-agent sweep repeatedly activated/prepared the same ragdoll.
- The existing ragdoll-state evaluator cached only `ActiveFirstTick`, then treated the persistent `Active` state as inactive.
- Multiple immediate/delayed/retry impulses could accumulate on a partially initialized body.

This violated the required invariant: Bannerlord must exclusively own the animation-to-ragdoll state transition. The mod may add force only after the engine reports an active ragdoll.

## Fix

- Remove the legacy lethal `RegisterBlow`, `MakeDead`, and `Die` overrides after Harmony registration.
- Disable the pre-death queue, periodic dead-ragdoll sweep, and legacy removal launch path.
- Observe the real fatal blow without mutating it.
- Wait for `RagdollState.ActiveFirstTick` or `RagdollState.Active`, then wait one solver-settle frame.
- Apply one capped impulse through the active-body physics API.
- Do not activate/wake/freeze/tick the ragdoll, register synthetic blows, or increase force on retries.
- Deduplicate each dead agent so successful impulses cannot stack.
- Preserve the original nonlethal knockback prefix and suppress it only for lethal blows, after TOR blow modifiers have run.
- Add compatibility fallbacks for older/newer `GameEntity` impulse APIs.

## Expected behavior

- Native death animations complete normally.
- The corpse receives the modded impulse only after the engine has created an active ragdoll.
- Failed/unsupported impulse routes drop the extra effect instead of corrupting the death transition.
- Living-agent knockback remains enabled.

## Validation performed

- Reviewed all lethal entry points and removed every reachable pre-death activation path from the new pipeline.
- Verified Bannerlord's active ragdoll states and current `GameEntityPhysicsExtensions` impulse route against 1.3.x managed API source.
- Verified branch is based directly on current `master` and changes only four files.

## Validation still required

This repository has no CI checks, and the connected environment does not contain the installed Bannerlord assemblies or a C# build toolchain. The branch therefore has not been compiled or exercised in-game here.

Test matrix before merge:

- nonlethal melee hit
- lethal melee hit with a long death animation
- arrow/bolt/headshot kill
- mounted/charge kill
- kills on slopes, stairs, near walls, and close to the ground
- rapid multi-kill and AOE/TOR magic deaths
- repeated hits on an already-dead agent
- confirm logs contain one `Safe corpse impulse applied` entry per affected corpse
- confirm no standing freeze, underground tunnelling, instant disappearance, or repeated launch pulses


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved death transitions to prevent conflicting physics effects and unintended ragdoll behavior.
  * Ensured fatal blows trigger ragdoll effects only after the game confirms the agent’s death.
  * Added safeguards to prevent duplicate, excessive, or unstable ragdoll impulses.
  * Improved handling of scripted deaths and delayed ragdoll activation.
* **Compatibility**
  * Enhanced support across compatible Bannerlord builds and physics configurations.
  * Added fallback handling when ragdoll or impulse capabilities are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->