### PR TITLE
Deliver post-death force through Agent ragdoll API

### DIFF
--- a/ExtremeRagdoll/ER_SafeDeathPipeline.cs
+++ b/ExtremeRagdoll/ER_SafeDeathPipeline.cs
@@ -445,9 +445,10 @@ namespace ExtremeRagdoll
                     if (now - pending.RagdollSeenAt < SolverSettleDelay)
                         continue;
 
-                    Vec3 force = pending.Direction * pending.ForceMagnitude;
-                    if (force.z < 0f)
-                        force.z = 0f;
+                    Vec3 direction = ER_DeathBlastBehavior.FinalizeImpulseDir(
+                        pending.Direction,
+                        ER_Config.CorpseLaunchMaxUpFraction);
+                    Vec3 force = direction * pending.ForceMagnitude;
 
                     bool applied;
                     try

--- a/ExtremeRagdoll/ER_SafeDeathPipeline.cs
+++ b/ExtremeRagdoll/ER_SafeDeathPipeline.cs
@@ -12,6 +12,9 @@ namespace ExtremeRagdoll
     internal static class ER_SafeDeathPipeline
     {
         private const string LegacyPatchId = "extremeragdoll.patch";
+        private const float ForceUnitsPerLegacyImpulseUnit = 2000f;
+        private const float MinimumUnitsPerLegacyImpulseUnit = 500f;
+        private const float AbsoluteForceCap = 16000f;
 
         internal static void DisableLegacyDeathOverrides(Harmony harmony)
         {
@@ -57,52 +60,39 @@ namespace ExtremeRagdoll
             return removed;
         }
 
-        internal static float ComputeImpulseMagnitude(in Blow blow)
+        internal static float ComputeRagdollForceMagnitude(in Blow blow)
         {
             float baseMagnitude = blow.BaseMagnitude;
             if (float.IsNaN(baseMagnitude) || float.IsInfinity(baseMagnitude) || baseMagnitude < 0f)
                 baseMagnitude = 0f;
 
-            float damage = blow.InflictedDamage;
-            if (float.IsNaN(damage) || float.IsInfinity(damage) || damage < 0f)
-                damage = 0f;
-
-            // Use the real fatal blow only as an input signal. The engine blow itself remains untouched.
-            // This range is strong enough to move an active ragdoll while staying below tunnelling speeds.
+            float damage = MathF.Max(0f, blow.InflictedDamage);
             float sourceMagnitude = MathF.Max(MathF.Min(baseMagnitude, 1200f), 250f + damage * 8f);
             float multiplier = MathF.Max(0f, ER_Config.ExtraForceMultiplier) * MathF.Max(1f, ER_Config.KnockbackMultiplier);
-            float impulse = sourceMagnitude * 1.0e-3f * multiplier;
+            float force = sourceMagnitude * multiplier;
 
-            float minimum = ER_Config.CorpseImpulseMinimum;
-            if (float.IsNaN(minimum) || float.IsInfinity(minimum) || minimum < 0f)
-                minimum = 0f;
-
-            float maximum = ER_Config.CorpseImpulseMaximum;
-            if (float.IsNaN(maximum) || float.IsInfinity(maximum) || maximum < 0f)
-                maximum = 0f;
-
+            float minimum = ER_Config.CorpseImpulseMinimum * MinimumUnitsPerLegacyImpulseUnit;
+            float maximum = ER_Config.CorpseImpulseMaximum * MinimumUnitsPerLegacyImpulseUnit;
             if (maximum > 0f && minimum > maximum)
                 minimum = maximum;
-            if (minimum > 0f && impulse < minimum)
-                impulse = minimum;
-            if (maximum > 0f && impulse > maximum)
-                impulse = maximum;
+            if (minimum > 0f && force < minimum)
+                force = minimum;
+            if (maximum > 0f && force > maximum)
+                force = maximum;
 
-            float hardCap = ER_Config.CorpseImpulseHardCap;
-            if (!float.IsNaN(hardCap) && !float.IsInfinity(hardCap) && hardCap > 0f && impulse > hardCap)
-                impulse = hardCap;
+            float configuredHardCap = ER_Config.CorpseImpulseHardCap;
+            if (configuredHardCap > 0f)
+                force = MathF.Min(force, configuredHardCap * ForceUnitsPerLegacyImpulseUnit);
+            force = MathF.Min(force, AbsoluteForceCap);
 
-            // A single capped impulse remains visible without recreating the old multi-pulse launch/tunnelling path.
-            const float AbsoluteSafeCap = 6.0f;
-            if (impulse > AbsoluteSafeCap)
-                impulse = AbsoluteSafeCap;
-
-            return float.IsNaN(impulse) || float.IsInfinity(impulse) || impulse <= 0f ? 0f : impulse;
+            return float.IsNaN(force) || float.IsInfinity(force) || force <= 0f ? 0f : force;
         }
 
         internal static Vec3 ResolveDirection(Agent agent, in Blow blow)
         {
             Vec3 direction = blow.SwingDirection;
+            if (!ER_Math.IsFinite(in direction) || direction.LengthSquared < ER_Math.DirectionTinySq)
+                direction = blow.Direction;
             if (!ER_Math.IsFinite(in direction) || direction.LengthSquared < ER_Math.DirectionTinySq)
             {
                 try { direction = agent.Position - blow.GlobalPosition; }
@@ -116,18 +106,9 @@ namespace ExtremeRagdoll
 
             direction = ER_DeathBlastBehavior.PrepDir(direction, 0.98f, 0.02f);
             direction = ER_DeathBlastBehavior.FinalizeImpulseDir(direction, ER_Config.CorpseLaunchMaxUpFraction);
-            if (!ER_Math.IsFinite(in direction) || direction.LengthSquared < ER_Math.DirectionTinySq)
-                return new Vec3(0f, 1f, 0f);
-            return direction;
-        }
-
-        internal static Vec3 ResolveContact(Agent agent)
-        {
-            Vec3 contact;
-            try { contact = agent.Position; }
-            catch { contact = Vec3.Zero; }
-            contact.z += 0.9f;
-            return contact;
+            return ER_Math.IsFinite(in direction) && direction.LengthSquared >= ER_Math.DirectionTinySq
+                ? direction
+                : new Vec3(0f, 1f, 0f);
         }
     }
 
@@ -138,9 +119,9 @@ namespace ExtremeRagdoll
         {
             internal bool Candidate;
             internal Vec3 Direction;
-            internal Vec3 Contact;
-            internal float ImpulseMagnitude;
+            internal float ForceMagnitude;
             internal float Time;
+            internal sbyte BoneIndex;
         }
 
         [HarmonyTargetMethods]
@@ -151,17 +132,21 @@ namespace ExtremeRagdoll
             {
                 if (candidate == null || candidate.Name != nameof(Agent.RegisterBlow))
                     continue;
+
                 ParameterInfo[] parameters = candidate.GetParameters();
                 if (parameters.Length == 0)
                     continue;
+
                 Type first = parameters[0].ParameterType;
                 if (first == blowType || (first.IsByRef && first.GetElementType() == blowType))
                     yield return candidate;
             }
         }
 
+        // Observe TOR's finalized blow before the lower-priority lethal suppression scope runs.
         [HarmonyPrefix]
-        [HarmonyPriority(Priority.First)]
+        [HarmonyPriority(Priority.Normal)]
+        [HarmonyAfter("TOR", "TOR_Core")]
         private static void Prefix(Agent __instance, [HarmonyArgument(0)] ref Blow blow, out CaptureState __state)
         {
             __state = default;
@@ -174,25 +159,22 @@ namespace ExtremeRagdoll
             if (float.IsNaN(health) || float.IsInfinity(health))
                 return;
 
-            float damage = blow.InflictedDamage;
-            if (float.IsNaN(damage) || float.IsInfinity(damage) || damage <= 0f)
+            int damage = blow.InflictedDamage;
+            bool lethal = health <= 0f || (damage > 0 && health - damage <= 0f);
+            if (!lethal)
                 return;
 
-            // Capture only a blow that can actually be fatal. The postfix confirms the final engine result.
-            if (health > 0f && health - damage > 0f)
-                return;
-
-            float impulse = ER_SafeDeathPipeline.ComputeImpulseMagnitude(in blow);
-            if (impulse <= 0f)
+            float force = ER_SafeDeathPipeline.ComputeRagdollForceMagnitude(in blow);
+            if (force <= 0f)
                 return;
 
             __state = new CaptureState
             {
                 Candidate = true,
                 Direction = ER_SafeDeathPipeline.ResolveDirection(__instance, in blow),
-                Contact = ER_SafeDeathPipeline.ResolveContact(__instance),
-                ImpulseMagnitude = impulse,
+                ForceMagnitude = force,
                 Time = __instance.Mission?.CurrentTime ?? Mission.Current?.CurrentTime ?? 0f,
+                BoneIndex = blow.BoneIndex,
             };
         }
 
@@ -212,15 +194,14 @@ namespace ExtremeRagdoll
             ER_SafeRagdollBehavior.Enqueue(
                 __instance,
                 __state.Direction,
-                __state.Contact,
-                __state.ImpulseMagnitude,
+                __state.ForceMagnitude,
                 __state.Time,
+                __state.BoneIndex,
                 "RegisterBlow");
         }
     }
 
-    // These legacy paths activate physics before Bannerlord has completed its death transition.
-    // Returning false leaves the engine animation/state machine in sole control of that transition.
+    // These paths took ownership of death before Bannerlord completed its animation/state transition.
     [HarmonyPatch]
     internal static class ER_DisableLegacyPreDeathQueuePatch
     {
@@ -255,7 +236,8 @@ namespace ExtremeRagdoll
     internal static class ER_DisableLegacyRemovedLaunchPatch
     {
         [HarmonyTargetMethod]
-        private static MethodBase TargetMethod() => AccessTools.Method(typeof(ER_DeathBlastBehavior), nameof(ER_DeathBlastBehavior.OnAgentRemoved));
+        private static MethodBase TargetMethod() =>
+            AccessTools.Method(typeof(ER_DeathBlastBehavior), nameof(ER_DeathBlastBehavior.OnAgentRemoved));
 
         [HarmonyPrefix]
         private static bool Prefix() => false;
@@ -265,20 +247,20 @@ namespace ExtremeRagdoll
     {
         private const float SolverSettleDelay = 0.033f;
         private const float RetryDelay = 0.05f;
-        private const float PendingLifetime = 8.0f;
-        private const int MaxApplyAttempts = 8;
+        private const float PendingLifetime = 8f;
+        private const int MaxApplyAttempts = 3;
 
         private sealed class PendingDeath
         {
             internal Agent Agent;
             internal int AgentIndex;
             internal Vec3 Direction;
-            internal Vec3 Contact;
-            internal float ImpulseMagnitude;
+            internal float ForceMagnitude;
             internal float CapturedAt;
             internal float RagdollSeenAt = -1f;
             internal float NextTryAt;
             internal int Attempts;
+            internal sbyte BoneIndex;
             internal string Source;
         }
 
@@ -292,9 +274,15 @@ namespace ExtremeRagdoll
             _instance = null;
         }
 
-        internal static void Enqueue(Agent agent, Vec3 direction, Vec3 contact, float impulseMagnitude, float capturedAt, string source)
+        internal static void Enqueue(
+            Agent agent,
+            Vec3 direction,
+            float forceMagnitude,
+            float capturedAt,
+            sbyte boneIndex,
+            string source)
         {
-            _instance?.EnqueueInternal(agent, direction, contact, impulseMagnitude, capturedAt, source);
+            _instance?.EnqueueInternal(agent, direction, forceMagnitude, capturedAt, boneIndex, source);
         }
 
         public override void OnBehaviorInitialize()
@@ -318,9 +306,15 @@ namespace ExtremeRagdoll
                 _instance = null;
         }
 
-        private void EnqueueInternal(Agent agent, Vec3 direction, Vec3 contact, float impulseMagnitude, float capturedAt, string source)
+        private void EnqueueInternal(
+            Agent agent,
+            Vec3 direction,
+            float forceMagnitude,
+            float capturedAt,
+            sbyte boneIndex,
+            string source)
         {
-            if (agent == null || impulseMagnitude <= 0f || !ER_Math.IsFinite(in direction) || !ER_Math.IsFinite(in contact))
+            if (agent == null || forceMagnitude <= 0f || !ER_Math.IsFinite(in direction))
                 return;
 
             int agentIndex;
@@ -338,12 +332,11 @@ namespace ExtremeRagdoll
                     if (!ReferenceEquals(existing.Agent, agent))
                         continue;
 
-                    // Retain the strongest observed fatal hit without creating stacked pulses.
-                    if (impulseMagnitude > existing.ImpulseMagnitude)
+                    if (forceMagnitude > existing.ForceMagnitude)
                     {
                         existing.Direction = direction;
-                        existing.Contact = contact;
-                        existing.ImpulseMagnitude = impulseMagnitude;
+                        existing.ForceMagnitude = forceMagnitude;
+                        existing.BoneIndex = boneIndex;
                         existing.Source = source;
                     }
                     return;
@@ -354,10 +347,10 @@ namespace ExtremeRagdoll
                     Agent = agent,
                     AgentIndex = agentIndex,
                     Direction = direction,
-                    Contact = contact,
-                    ImpulseMagnitude = impulseMagnitude,
+                    ForceMagnitude = forceMagnitude,
                     CapturedAt = capturedAt,
                     NextTryAt = capturedAt,
+                    BoneIndex = boneIndex,
                     Source = source ?? "unknown",
                 });
             }
@@ -377,7 +370,6 @@ namespace ExtremeRagdoll
                         return;
             }
 
-            // Scripted deaths may bypass RegisterBlow. Queue a conservative fallback and still wait for real ragdoll state.
             Vec3 direction;
             try { direction = affected.LookDirection; }
             catch { direction = new Vec3(0f, 1f, 0f); }
@@ -385,15 +377,14 @@ namespace ExtremeRagdoll
                 ER_DeathBlastBehavior.PrepDir(direction, 0.98f, 0.02f),
                 ER_Config.CorpseLaunchMaxUpFraction);
 
-            float fallbackImpulse = 0.60f * MathF.Max(1f, ER_Config.KnockbackMultiplier);
+            float fallbackForce = 2500f * MathF.Max(1f, ER_Config.KnockbackMultiplier);
             float hardCap = ER_Config.CorpseImpulseHardCap;
-            if (hardCap > 0f && fallbackImpulse > hardCap)
-                fallbackImpulse = hardCap;
-            if (fallbackImpulse > 1.25f)
-                fallbackImpulse = 1.25f;
+            if (hardCap > 0f)
+                fallbackForce = MathF.Min(fallbackForce, hardCap * 2000f);
+            fallbackForce = MathF.Min(fallbackForce, 16000f);
 
             float now = Mission?.CurrentTime ?? affected.Mission?.CurrentTime ?? 0f;
-            EnqueueInternal(affected, direction, ER_SafeDeathPipeline.ResolveContact(affected), fallbackImpulse, now, "OnAgentRemoved");
+            EnqueueInternal(affected, direction, fallbackForce, now, -1, "OnAgentRemoved");
         }
 
         public override void OnMissionTick(float dt)
@@ -426,10 +417,9 @@ namespace ExtremeRagdoll
                     if (float.IsNaN(health) || float.IsInfinity(health) || health > 0f)
                         continue;
 
-                    GameEntity entity = null;
-                    Skeleton skeleton = null;
-                    try { entity = agent.AgentVisuals?.GetEntity(); } catch { entity = null; }
-                    try { skeleton = agent.AgentVisuals?.GetSkeleton(); } catch { skeleton = null; }
+                    Skeleton skeleton;
+                    try { skeleton = agent.AgentVisuals?.GetSkeleton(); }
+                    catch { skeleton = null; }
                     if (skeleton == null)
                     {
                         pending.NextTryAt = now + RetryDelay;
@@ -441,8 +431,7 @@ namespace ExtremeRagdoll
                     catch { ragdollActive = false; }
                     if (!ragdollActive)
                     {
-                        // No activation, animation ticking, synthetic blow, or wake call here.
-                        // Bannerlord owns the complete death-animation-to-ragdoll transition.
+                        // Bannerlord remains the sole owner of the death animation and transition.
                         pending.NextTryAt = now + RetryDelay;
                         continue;
                     }
@@ -456,19 +445,18 @@ namespace ExtremeRagdoll
                     if (now - pending.RagdollSeenAt < SolverSettleDelay)
                         continue;
 
-                    Vec3 contact = ER_DeathBlastBehavior.ClampHitToBody(agent, pending.Contact);
-                    Vec3 impulse = pending.Direction * pending.ImpulseMagnitude;
-                    if (impulse.z < 0f)
-                        impulse.z = 0f;
+                    Vec3 force = pending.Direction * pending.ForceMagnitude;
+                    if (force.z < 0f)
+                        force.z = 0f;
 
-                    bool applied = false;
+                    bool applied;
                     try
                     {
                         applied = ER_ActiveRagdollImpulse.TryApply(
-                            entity,
+                            agent,
                             skeleton,
-                            in impulse,
-                            in contact);
+                            pending.BoneIndex,
+                            in force);
                     }
                     catch
                     {
@@ -480,7 +468,7 @@ namespace ExtremeRagdoll
                         _completed.Add(agent);
                         _pending.RemoveAt(i);
                         if (ER_Config.DebugLogging)
-                            ER_Log.Info($"Safe corpse impulse applied Agent#{pending.AgentIndex} source={pending.Source} impulse={pending.ImpulseMagnitude:0.00}");
+                            ER_Log.Info($"Safe corpse force applied Agent#{pending.AgentIndex} source={pending.Source} bone={pending.BoneIndex} force={pending.ForceMagnitude:0}");
                         continue;
                     }
 
@@ -489,7 +477,7 @@ namespace ExtremeRagdoll
                     {
                         _pending.RemoveAt(i);
                         if (ER_Config.DebugLogging)
-                            ER_Log.Info($"Safe corpse impulse dropped Agent#{pending.AgentIndex}: active ragdoll rejected {pending.Attempts} attempt(s)");
+                            ER_Log.Info($"Safe corpse force dropped Agent#{pending.AgentIndex}: active ragdoll rejected {pending.Attempts} attempt(s)");
                     }
                     else
                     {

--- a/ExtremeRagdoll/ER_SafeImpulseBridge.cs
+++ b/ExtremeRagdoll/ER_SafeImpulseBridge.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Reflection;
-using System.Threading;
 using HarmonyLib;
 using TaleWorlds.Core;
 using TaleWorlds.Engine;
@@ -10,8 +9,7 @@ using TaleWorlds.MountAndBlade;
 
 namespace ExtremeRagdoll
 {
-    // The legacy evaluator caches the first enum name containing "active". Bannerlord declares
-    // ActiveFirstTick before Active, so the persistent Active state was incorrectly treated as inactive.
+    // The legacy evaluator cached ActiveFirstTick and then rejected the persistent Active state.
     [HarmonyPatch(typeof(ER_DeathBlastBehavior), "IsRagdollActiveFast")]
     internal static class ER_ExactRagdollStatePatch
     {
@@ -34,6 +32,7 @@ namespace ExtremeRagdoll
             {
                 __result = false;
             }
+
             return false;
         }
     }
@@ -58,9 +57,11 @@ namespace ExtremeRagdoll
             {
                 if (original == null || original.Name != nameof(Agent.RegisterBlow))
                     continue;
+
                 ParameterInfo[] parameters = original.GetParameters();
                 if (parameters.Length == 0)
                     continue;
+
                 Type first = parameters[0].ParameterType;
                 if (first != blowType && !(first.IsByRef && first.GetElementType() == blowType))
                     continue;
@@ -86,8 +87,8 @@ namespace ExtremeRagdoll
     }
 
     /// <summary>
-    /// Keeps the original knockback amplifier for living targets while preventing it from touching a lethal blow.
-    /// The scope remains active until Harmony finalizers run, covering the old late-priority prefix.
+    /// Keeps the old living-target knockback path while preventing it from mutating lethal blows.
+    /// TOR runs first, capture observes the finalized blow, this scope then suppresses the old late prefix.
     /// </summary>
     [HarmonyPatch]
     internal static class ER_SuppressLegacyLethalRegisterBlowPatch
@@ -100,9 +101,11 @@ namespace ExtremeRagdoll
             {
                 if (candidate == null || candidate.Name != nameof(Agent.RegisterBlow))
                     continue;
+
                 ParameterInfo[] parameters = candidate.GetParameters();
                 if (parameters.Length == 0)
                     continue;
+
                 Type first = parameters[0].ParameterType;
                 if (first == blowType || (first.IsByRef && first.GetElementType() == blowType))
                     yield return candidate;
@@ -127,11 +130,8 @@ namespace ExtremeRagdoll
             if (float.IsNaN(health) || float.IsInfinity(health))
                 return;
 
-            float damage = blow.InflictedDamage;
-            if (float.IsNaN(damage) || float.IsInfinity(damage))
-                damage = 0f;
-
-            bool lethal = health <= 0f || (damage > 0f && health - damage <= 0f);
+            int damage = blow.InflictedDamage;
+            bool lethal = health <= 0f || (damage > 0 && health - damage <= 0f);
             if (lethal)
                 __state = ER_Amplify_RegisterBlowPatch.SuppressPrefixScope();
         }
@@ -147,225 +147,75 @@ namespace ExtremeRagdoll
     }
 
     /// <summary>
-    /// Applies one impulse to a body that Bannerlord has already converted to ragdoll.
-    /// No route in this class activates, wakes, ticks, freezes, or otherwise changes ragdoll state.
+    /// Applies force through Bannerlord's agent-ragdoll API after the engine owns and completes
+    /// the animation-to-ragdoll transition. This class never activates, wakes, freezes, ticks,
+    /// teleports, or registers another blow.
     /// </summary>
     internal static class ER_ActiveRagdollImpulse
     {
-        private static readonly object BindLock = new object();
-        private static int _bound;
+        private const float LinearVelocityLimit = 25f;
+        private const float AngularVelocityLimit = 60f;
 
-        // Bannerlord 1.3.x: local contact + global force + ForceMode.Impulse.
-        private static MethodInfo _globalForceAtLocalPos;
-        private static object _impulseForceMode;
-
-        // Compatibility routes used by older/newer engine builds.
-        private static MethodInfo _worldImpulseInstance3;
-        private static MethodInfo _worldImpulseExtension4;
-        private static MethodInfo _worldImpulseInstance2;
-        private static MethodInfo _localImpulseInstance2;
-        private static MethodInfo _localImpulseExtension3;
-
-        private static int _missingRouteLogged;
-
-        internal static bool TryApply(GameEntity entity, Skeleton skeleton, in Vec3 worldImpulse, in Vec3 worldPosition)
+        internal static bool TryApply(Agent agent, Skeleton skeleton, sbyte requestedBoneIndex, in Vec3 worldForce)
         {
-            if (entity == null || skeleton == null)
+            if (agent == null || skeleton == null)
                 return false;
-            if (!ER_Math.IsFinite(in worldImpulse) || !ER_Math.IsFinite(in worldPosition))
-                return false;
-            if (worldImpulse.LengthSquared < ER_Math.ImpulseTinySq)
+            if (!ER_Math.IsFinite(in worldForce) || worldForce.LengthSquared < ER_Math.ImpulseTinySq)
                 return false;
 
-            bool ragdollActive;
-            try { ragdollActive = ER_DeathBlastBehavior.IsRagdollActiveFast(skeleton); }
-            catch { ragdollActive = false; }
-            if (!ragdollActive)
-                return false;
-
-            bool hasPhysicsBody;
-            try { hasPhysicsBody = entity.HasPhysicsBody(); }
-            catch { hasPhysicsBody = false; }
-            if (!hasPhysicsBody)
-                return false;
-
-            Vec3 min;
-            Vec3 max;
-            try
-            {
-                min = entity.GetPhysicsBoundingBoxMin();
-                max = entity.GetPhysicsBoundingBoxMax();
-            }
-            catch
-            {
-                return false;
-            }
-            if (!ER_Math.IsFinite(in min) || !ER_Math.IsFinite(in max))
-                return false;
-            Vec3 extent = max - min;
-            if (!ER_Math.IsFinite(in extent) || extent.x <= 0f || extent.y <= 0f || extent.z <= 0f)
-                return false;
-            float maxExtent = ER_Config.MaxAabbExtent;
-            if (float.IsNaN(maxExtent) || float.IsInfinity(maxExtent) || maxExtent <= 0f)
-                maxExtent = 1024f;
-            if (extent.x > maxExtent || extent.y > maxExtent || extent.z > maxExtent)
-                return false;
-
-            MatrixFrame frame;
-            try { frame = entity.GetGlobalFrame(); }
+            RagdollState state;
+            try { state = skeleton.GetCurrentRagdollState(); }
             catch { return false; }
-
-            Vec3 localPosition = WorldPointToLocal(in frame, in worldPosition);
-            Vec3 localImpulse = WorldVectorToLocal(in frame, in worldImpulse);
-            if (!ER_Math.IsFinite(in localPosition) || !ER_Math.IsFinite(in localImpulse))
+            if (state != RagdollState.ActiveFirstTick && state != RagdollState.Active)
                 return false;
 
-            EnsureBound();
-
+            sbyte boneIndex = ResolveBoneIndex(skeleton, requestedBoneIndex);
             try
             {
-                if (_globalForceAtLocalPos != null && _impulseForceMode != null)
-                {
-                    _globalForceAtLocalPos.Invoke(
-                        null,
-                        new[] { (object)entity, localPosition, worldImpulse, _impulseForceMode });
-                    return true;
-                }
+                // Limit pathological tunnelling without weakening ordinary/extreme reactions.
+                agent.SetVelocityLimitsOnRagdoll(LinearVelocityLimit, AngularVelocityLimit);
+                agent.ApplyForceOnRagdoll(boneIndex, in worldForce);
 
-                if (_worldImpulseInstance3 != null)
-                {
-                    _worldImpulseInstance3.Invoke(entity, new object[] { worldImpulse, worldPosition, false });
-                    return true;
-                }
-
-                if (_worldImpulseExtension4 != null)
-                {
-                    _worldImpulseExtension4.Invoke(null, new object[] { entity, worldImpulse, worldPosition, false });
-                    return true;
-                }
-
-                // Legacy GameEntity API: position first, impulse second.
-                if (_worldImpulseInstance2 != null)
-                {
-                    _worldImpulseInstance2.Invoke(entity, new object[] { worldPosition, worldImpulse });
-                    return true;
-                }
-
-                if (_localImpulseInstance2 != null)
-                {
-                    _localImpulseInstance2.Invoke(entity, new object[] { localPosition, localImpulse });
-                    return true;
-                }
-
-                if (_localImpulseExtension3 != null)
-                {
-                    _localImpulseExtension3.Invoke(null, new object[] { entity, localPosition, localImpulse });
-                    return true;
-                }
-            }
-            catch (TargetInvocationException ex)
-            {
-                Exception inner = ex.InnerException ?? ex;
                 if (ER_Config.DebugLogging)
-                    ER_Log.Error("Safe active-ragdoll impulse failed", inner);
-                return false;
+                    ER_Log.Info($"Safe ragdoll force route=Agent.ApplyForceOnRagdoll bone={boneIndex} force={MathF.Sqrt(worldForce.LengthSquared):0}");
+                return true;
             }
             catch (Exception ex)
             {
                 if (ER_Config.DebugLogging)
-                    ER_Log.Error("Safe active-ragdoll impulse failed", ex);
+                    ER_Log.Error("Safe Agent.ApplyForceOnRagdoll failed", ex);
                 return false;
             }
-
-            if (Interlocked.Exchange(ref _missingRouteLogged, 1) == 0)
-                ER_Log.Error("Safe active-ragdoll impulse disabled: no compatible GameEntity impulse API was found");
-            return false;
         }
 
-        private static Vec3 WorldPointToLocal(in MatrixFrame frame, in Vec3 worldPoint)
+        private static sbyte ResolveBoneIndex(Skeleton skeleton, sbyte requested)
         {
-            Vec3 delta = worldPoint - frame.origin;
-            return WorldVectorToLocal(in frame, in delta);
-        }
+            int count;
+            try { count = skeleton.GetBoneCount(); }
+            catch { return requested >= 0 ? requested : (sbyte)0; }
 
-        private static Vec3 WorldVectorToLocal(in MatrixFrame frame, in Vec3 worldVector)
-        {
-            return new Vec3(
-                frame.rotation.s.x * worldVector.x + frame.rotation.s.y * worldVector.y + frame.rotation.s.z * worldVector.z,
-                frame.rotation.f.x * worldVector.x + frame.rotation.f.y * worldVector.y + frame.rotation.f.z * worldVector.z,
-                frame.rotation.u.x * worldVector.x + frame.rotation.u.y * worldVector.y + frame.rotation.u.z * worldVector.z);
-        }
+            if (count <= 0)
+                return 0;
+            if (requested >= 0 && requested < count)
+                return requested;
 
-        private static void EnsureBound()
-        {
-            if (Volatile.Read(ref _bound) != 0)
-                return;
-
-            lock (BindLock)
+            string[] preferred = { "pelvis", "hips", "spine_0", "spine", "root" };
+            for (int p = 0; p < preferred.Length; p++)
             {
-                if (_bound != 0)
-                    return;
-
-                const BindingFlags InstanceFlags = BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic;
-                const BindingFlags StaticFlags = BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic;
-
-                Type gameEntityType = typeof(GameEntity);
-                Type vec3Type = typeof(Vec3);
-                Type extensions = gameEntityType.Assembly.GetType("TaleWorlds.Engine.GameEntityPhysicsExtensions");
-
-                _worldImpulseInstance3 = gameEntityType.GetMethod(
-                    "ApplyImpulseToDynamicBody",
-                    InstanceFlags,
-                    null,
-                    new[] { vec3Type, vec3Type, typeof(bool) },
-                    null);
-
-                _worldImpulseInstance2 = gameEntityType.GetMethod(
-                    "ApplyImpulseToDynamicBody",
-                    InstanceFlags,
-                    null,
-                    new[] { vec3Type, vec3Type },
-                    null);
-
-                _localImpulseInstance2 = gameEntityType.GetMethod(
-                    "ApplyLocalImpulseToDynamicBody",
-                    InstanceFlags,
-                    null,
-                    new[] { vec3Type, vec3Type },
-                    null);
-
-                if (extensions != null)
+                for (int i = 0; i < count && i <= sbyte.MaxValue; i++)
                 {
-                    _worldImpulseExtension4 = extensions.GetMethod(
-                        "ApplyImpulseToDynamicBody",
-                        StaticFlags,
-                        null,
-                        new[] { gameEntityType, vec3Type, vec3Type, typeof(bool) },
-                        null);
-
-                    _localImpulseExtension3 = extensions.GetMethod(
-                        "ApplyLocalImpulseToDynamicBody",
-                        StaticFlags,
-                        null,
-                        new[] { gameEntityType, vec3Type, vec3Type },
-                        null);
-
-                    Type forceModeType = extensions.GetNestedType("ForceMode", BindingFlags.Public | BindingFlags.NonPublic);
-                    if (forceModeType != null && forceModeType.IsEnum)
+                    try
                     {
-                        _globalForceAtLocalPos = extensions.GetMethod(
-                            "ApplyGlobalForceAtLocalPosToDynamicBody",
-                            StaticFlags,
-                            null,
-                            new[] { gameEntityType, vec3Type, vec3Type, forceModeType },
-                            null);
-                        if (_globalForceAtLocalPos != null)
-                            _impulseForceMode = Enum.ToObject(forceModeType, 1);
+                        string name = skeleton.GetBoneName((sbyte)i);
+                        if (!string.IsNullOrEmpty(name) &&
+                            name.IndexOf(preferred[p], StringComparison.OrdinalIgnoreCase) >= 0)
+                            return (sbyte)i;
                     }
+                    catch { }
                 }
-
-                Volatile.Write(ref _bound, 1);
             }
+
+            return 0;
         }
     }
 }


### PR DESCRIPTION
## Regression

After #143, death animations were preserved, but the visible Extreme Ragdoll effect disappeared.

The runtime log shows the safe pipeline loading, lethal blows being suppressed/captured, and active ragdolls being detected. Every delivery attempt then ended with:

```
Safe corpse impulse dropped Agent#...: active ragdoll rejected 8 attempt(s)
```

No successful impulse was recorded.

## Root cause

The merged safe path attempted to deliver force through generic `GameEntity` dynamic-body APIs and required the visual root entity to report a valid physics body/AABB. Bannerlord agent ragdolls are owned and controlled through `Agent`, while the visual root entity can report no dynamic body. The gate therefore rejected every active ragdoll.

The old `3-6` impulse scale was also inappropriate for Bannerlord's dedicated ragdoll-force API. Bannerlord's own corpse interaction logic uses `Agent.ApplyForceOnRagdoll` with forces in the thousands.

## Fix

- Replace the generic `GameEntity` impulse router with `Agent.ApplyForceOnRagdoll`.
- Carry the fatal blow's actual `BoneIndex` through the safe queue.
- Resolve invalid bone indices to pelvis/hips/spine/root.
- Scale the configured effect into Bannerlord ragdoll-force units, capped at 16,000.
- Set conservative ragdoll velocity limits of 25 linear / 60 angular to prevent tunnelling and runaway launches.
- Apply the force once, after Bannerlord reports `ActiveFirstTick` or `Active` and after one solver-settle frame.
- Reduce failed delivery retries from eight to three.
- Capture the finalized blow after TOR modifiers, before the legacy lethal prefix is suppressed.
- Keep native death animations untouched and preserve the existing nonlethal knockback path.

## Expected runtime log

A successful lethal reaction should now produce both:

```
Safe ragdoll force route=Agent.ApplyForceOnRagdoll bone=... force=...
Safe corpse force applied Agent#... source=RegisterBlow ...
```

There should be no pre-death activation, synthetic blow, repeated successful pulse, standing freeze, underground tunnelling, or instant disappearance.

## Validation

- Branch is based directly on current `master` and is two commits ahead, zero behind.
- Verified the API against Bannerlord 1.3.x managed source: `Agent.ApplyForceOnRagdoll(sbyte, in Vec3)` and `SetVelocityLimitsOnRagdoll`.
- Verified Bannerlord's corpse-dragging logic uses the same ragdoll-specific route.

The repository has no CI and this environment does not contain the installed Bannerlord assemblies, so compilation and in-game behavior still require local validation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ragdoll behavior after lethal blows with more consistent force and direction handling.
  * Added stronger safeguards for physics force application to reduce unstable movement.
  * Enhanced fallback behavior when ragdoll activation or skeleton data is delayed.
  * Reduced repeated application attempts and improved merging so the strongest hit is retained.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->