### PR TITLE
Restore Bannerlord 1.2.12 build compatibility

### DIFF
--- a/ExtremeRagdoll/ER_SafeDeathPipeline.cs
+++ b/ExtremeRagdoll/ER_SafeDeathPipeline.cs
@@ -15,6 +15,8 @@ namespace ExtremeRagdoll
         private const float ForceUnitsPerLegacyImpulseUnit = 2000f;
         private const float MinimumUnitsPerLegacyImpulseUnit = 500f;
         private const float AbsoluteForceCap = 16000f;
+        private const float LegacyMeleeMagnitudeCap = 2200f;
+        private const float LegacyMissileMagnitudeCap = 1400f;
 
         internal static void DisableLegacyDeathOverrides(Harmony harmony)
         {
@@ -66,7 +68,7 @@ namespace ExtremeRagdoll
             if (float.IsNaN(baseMagnitude) || float.IsInfinity(baseMagnitude) || baseMagnitude < 0f)
                 baseMagnitude = 0f;
 
-            float damage = MathF.Max(0f, blow.InflictedDamage);
+            float damage = MathF.Max(0f, (float)blow.InflictedDamage);
             float sourceMagnitude = MathF.Max(MathF.Min(baseMagnitude, 1200f), 250f + damage * 8f);
             float multiplier = MathF.Max(0f, ER_Config.ExtraForceMultiplier) * MathF.Max(1f, ER_Config.KnockbackMultiplier);
             float force = sourceMagnitude * multiplier;
@@ -81,7 +83,7 @@ namespace ExtremeRagdoll
                 force = maximum;
 
             float configuredHardCap = ER_Config.CorpseImpulseHardCap;
-            if (configuredHardCap > 0f)
+            if (!float.IsNaN(configuredHardCap) && !float.IsInfinity(configuredHardCap) && configuredHardCap > 0f)
                 force = MathF.Min(force, configuredHardCap * ForceUnitsPerLegacyImpulseUnit);
             force = MathF.Min(force, AbsoluteForceCap);
 
@@ -109,6 +111,51 @@ namespace ExtremeRagdoll
             return ER_Math.IsFinite(in direction) && direction.LengthSquared >= ER_Math.DirectionTinySq
                 ? direction
                 : new Vec3(0f, 1f, 0f);
+        }
+
+        internal static void ApplyLegacyFatalBlowFallback(Agent agent, ref Blow blow)
+        {
+            float originalMagnitude = blow.BaseMagnitude;
+            if (float.IsNaN(originalMagnitude) || float.IsInfinity(originalMagnitude) || originalMagnitude < 0f)
+                originalMagnitude = 0f;
+
+            float damage = MathF.Max(0f, (float)blow.InflictedDamage);
+            float multiplier = MathF.Max(1f, ER_Config.ExtraForceMultiplier) *
+                               MathF.Max(1f, ER_Config.KnockbackMultiplier);
+            multiplier = MathF.Min(multiplier, 3f);
+
+            bool missile = false;
+            try
+            {
+                string flags = blow.BlowFlag.ToString();
+                missile = !string.IsNullOrEmpty(flags) &&
+                          flags.IndexOf("Missile", StringComparison.OrdinalIgnoreCase) >= 0;
+            }
+            catch { }
+
+            float cap = missile ? LegacyMissileMagnitudeCap : LegacyMeleeMagnitudeCap;
+            float configuredHardCap = ER_Config.CorpseImpulseHardCap;
+            if (!float.IsNaN(configuredHardCap) && !float.IsInfinity(configuredHardCap) && configuredHardCap > 0f)
+                cap = MathF.Min(cap, configuredHardCap * 350f);
+
+            float floor = missile ? 900f : 1200f;
+            if (floor > cap)
+                floor = cap;
+
+            float source = MathF.Max(originalMagnitude, 500f + damage * 10f);
+            float desired = MathF.Min(source * multiplier, cap);
+            if (desired < floor)
+                desired = floor;
+
+            if (desired > originalMagnitude)
+                blow.BaseMagnitude = desired;
+
+            Vec3 swing = blow.SwingDirection;
+            if (!ER_Math.IsFinite(in swing) || swing.LengthSquared < ER_Math.DirectionTinySq || swing.z < 0f)
+                blow.SwingDirection = ResolveDirection(agent, in blow);
+
+            if (ER_Config.DebugLogging)
+                ER_Log.Info($"Safe fatal-blow compatibility route magnitude={blow.BaseMagnitude:0} missile={missile}");
         }
     }
 
@@ -143,7 +190,6 @@ namespace ExtremeRagdoll
             }
         }
 
-        // Observe TOR's finalized blow before the lower-priority lethal suppression scope runs.
         [HarmonyPrefix]
         [HarmonyPriority(Priority.Normal)]
         [HarmonyAfter("TOR", "TOR_Core")]
@@ -163,6 +209,12 @@ namespace ExtremeRagdoll
             bool lethal = health <= 0f || (damage > 0 && health - damage <= 0f);
             if (!lethal)
                 return;
+
+            if (!ER_ActiveRagdollImpulse.HasAgentForceRoute)
+            {
+                ER_SafeDeathPipeline.ApplyLegacyFatalBlowFallback(__instance, ref blow);
+                return;
+            }
 
             float force = ER_SafeDeathPipeline.ComputeRagdollForceMagnitude(in blow);
             if (force <= 0f)
@@ -201,7 +253,6 @@ namespace ExtremeRagdoll
         }
     }
 
-    // These paths took ownership of death before Bannerlord completed its animation/state transition.
     [HarmonyPatch]
     internal static class ER_DisableLegacyPreDeathQueuePatch
     {
@@ -360,6 +411,8 @@ namespace ExtremeRagdoll
         {
             if (affected == null || state != AgentState.Killed)
                 return;
+            if (!ER_ActiveRagdollImpulse.HasAgentForceRoute)
+                return;
 
             lock (_gate)
             {
@@ -379,7 +432,7 @@ namespace ExtremeRagdoll
 
             float fallbackForce = 2500f * MathF.Max(1f, ER_Config.KnockbackMultiplier);
             float hardCap = ER_Config.CorpseImpulseHardCap;
-            if (hardCap > 0f)
+            if (!float.IsNaN(hardCap) && !float.IsInfinity(hardCap) && hardCap > 0f)
                 fallbackForce = MathF.Min(fallbackForce, hardCap * 2000f);
             fallbackForce = MathF.Min(fallbackForce, 16000f);
 
@@ -431,7 +484,6 @@ namespace ExtremeRagdoll
                     catch { ragdollActive = false; }
                     if (!ragdollActive)
                     {
-                        // Bannerlord remains the sole owner of the death animation and transition.
                         pending.NextTryAt = now + RetryDelay;
                         continue;
                     }

--- a/ExtremeRagdoll/ER_SafeImpulseBridge.cs
+++ b/ExtremeRagdoll/ER_SafeImpulseBridge.cs
@@ -147,14 +147,29 @@ namespace ExtremeRagdoll
     }
 
     /// <summary>
-    /// Applies force through Bannerlord's agent-ragdoll API after the engine owns and completes
-    /// the animation-to-ragdoll transition. This class never activates, wakes, freezes, ticks,
-    /// teleports, or registers another blow.
+    /// Applies force through Bannerlord's dedicated Agent ragdoll API when that API exists.
+    /// Bannerlord 1.2.12 does not expose these methods, so all binding is reflective and the
+    /// safe death pipeline uses the original fatal blow as its compatibility route instead.
     /// </summary>
     internal static class ER_ActiveRagdollImpulse
     {
         private const float LinearVelocityLimit = 25f;
         private const float AngularVelocityLimit = 60f;
+
+        private static readonly object BindLock = new object();
+        private static bool _bound;
+        private static MethodInfo _applyForceOnRagdoll;
+        private static MethodInfo _setVelocityLimitsOnRagdoll;
+        private static bool _missingRouteLogged;
+
+        internal static bool HasAgentForceRoute
+        {
+            get
+            {
+                EnsureBound();
+                return _applyForceOnRagdoll != null;
+            }
+        }
 
         internal static bool TryApply(Agent agent, Skeleton skeleton, sbyte requestedBoneIndex, in Vec3 worldForce)
         {
@@ -169,23 +184,135 @@ namespace ExtremeRagdoll
             if (state != RagdollState.ActiveFirstTick && state != RagdollState.Active)
                 return false;
 
+            EnsureBound();
+            if (_applyForceOnRagdoll == null)
+            {
+                LogMissingRouteOnce();
+                return false;
+            }
+
             sbyte boneIndex = ResolveBoneIndex(skeleton, requestedBoneIndex);
             try
             {
-                // Limit pathological tunnelling without weakening ordinary/extreme reactions.
-                agent.SetVelocityLimitsOnRagdoll(LinearVelocityLimit, AngularVelocityLimit);
-                agent.ApplyForceOnRagdoll(boneIndex, in worldForce);
+                if (_setVelocityLimitsOnRagdoll != null)
+                {
+                    _setVelocityLimitsOnRagdoll.Invoke(
+                        agent,
+                        new object[] { LinearVelocityLimit, AngularVelocityLimit });
+                }
+
+                ParameterInfo[] parameters = _applyForceOnRagdoll.GetParameters();
+                object boneArgument = BoxInteger(parameters[0].ParameterType, boneIndex);
+                _applyForceOnRagdoll.Invoke(agent, new object[] { boneArgument, worldForce });
 
                 if (ER_Config.DebugLogging)
-                    ER_Log.Info($"Safe ragdoll force route=Agent.ApplyForceOnRagdoll bone={boneIndex} force={MathF.Sqrt(worldForce.LengthSquared):0}");
+                {
+                    string route = _applyForceOnRagdoll.DeclaringType?.Name + "." + _applyForceOnRagdoll.Name;
+                    ER_Log.Info($"Safe ragdoll force route={route} bone={boneIndex} force={Math.Sqrt(worldForce.LengthSquared):0}");
+                }
                 return true;
+            }
+            catch (TargetInvocationException ex)
+            {
+                if (ER_Config.DebugLogging)
+                    ER_Log.Error("Safe Agent ragdoll-force invocation failed", ex.InnerException ?? ex);
+                return false;
             }
             catch (Exception ex)
             {
                 if (ER_Config.DebugLogging)
-                    ER_Log.Error("Safe Agent.ApplyForceOnRagdoll failed", ex);
+                    ER_Log.Error("Safe Agent ragdoll-force invocation failed", ex);
                 return false;
             }
+        }
+
+        private static void EnsureBound()
+        {
+            if (_bound)
+                return;
+
+            lock (BindLock)
+            {
+                if (_bound)
+                    return;
+
+                const BindingFlags Flags = BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic;
+                MethodInfo[] methods;
+                try { methods = typeof(Agent).GetMethods(Flags); }
+                catch { methods = Array.Empty<MethodInfo>(); }
+
+                for (int i = 0; i < methods.Length; i++)
+                {
+                    MethodInfo method = methods[i];
+                    if (method == null)
+                        continue;
+
+                    ParameterInfo[] parameters;
+                    try { parameters = method.GetParameters(); }
+                    catch { continue; }
+
+                    if (method.Name == "ApplyForceOnRagdoll" &&
+                        parameters.Length == 2 &&
+                        IsInteger(parameters[0].ParameterType) &&
+                        IsVec3(parameters[1].ParameterType))
+                    {
+                        _applyForceOnRagdoll = method;
+                        continue;
+                    }
+
+                    if (method.Name == "SetVelocityLimitsOnRagdoll" &&
+                        parameters.Length == 2 &&
+                        Unwrap(parameters[0].ParameterType) == typeof(float) &&
+                        Unwrap(parameters[1].ParameterType) == typeof(float))
+                    {
+                        _setVelocityLimitsOnRagdoll = method;
+                    }
+                }
+
+                _bound = true;
+            }
+        }
+
+        private static void LogMissingRouteOnce()
+        {
+            lock (BindLock)
+            {
+                if (_missingRouteLogged)
+                    return;
+                _missingRouteLogged = true;
+            }
+
+            if (ER_Config.DebugLogging)
+                ER_Log.Info("Dedicated Agent ragdoll-force API unavailable; using fatal-blow compatibility route");
+        }
+
+        private static Type Unwrap(Type type)
+        {
+            return type != null && type.IsByRef ? type.GetElementType() : type;
+        }
+
+        private static bool IsVec3(Type type)
+        {
+            return Unwrap(type) == typeof(Vec3);
+        }
+
+        private static bool IsInteger(Type type)
+        {
+            type = Unwrap(type);
+            return type == typeof(sbyte) || type == typeof(byte) ||
+                   type == typeof(short) || type == typeof(ushort) ||
+                   type == typeof(int) || type == typeof(uint);
+        }
+
+        private static object BoxInteger(Type type, int value)
+        {
+            type = Unwrap(type);
+            if (type == typeof(sbyte)) return (sbyte)Math.Max(sbyte.MinValue, Math.Min(sbyte.MaxValue, value));
+            if (type == typeof(byte)) return (byte)Math.Max(byte.MinValue, Math.Min(byte.MaxValue, value));
+            if (type == typeof(short)) return (short)Math.Max(short.MinValue, Math.Min(short.MaxValue, value));
+            if (type == typeof(ushort)) return (ushort)Math.Max(ushort.MinValue, Math.Min(ushort.MaxValue, value));
+            if (type == typeof(uint)) return (uint)Math.Max(0, value);
+            return value;
         }
 
         private static sbyte ResolveBoneIndex(Skeleton skeleton, sbyte requested)


### PR DESCRIPTION
## Failure

The merged #144 code does not compile against the Bannerlord 1.2.12 assemblies used by The Old Realms:

- `MathF.Max(float, int)` triggers TaleWorlds' obsolete mixed-type overload error.
- `Agent.ApplyForceOnRagdoll` does not exist in 1.2.12.
- `Agent.SetVelocityLimitsOnRagdoll` does not exist in 1.2.12.

The dedicated Agent ragdoll-force APIs were added in Bannerlord 1.3.x. They are absent from both the public `Agent` type and the native `IMBAgent` interface in 1.2.12.

## Fix

- Cast `Blow.InflictedDamage` to `float` before using `MathF.Max`.
- Remove all compile-time references to the 1.3-only Agent methods.
- Bind `ApplyForceOnRagdoll` and `SetVelocityLimitsOnRagdoll` reflectively when running on a game version that exposes them.
- On Bannerlord 1.2.12, use the real fatal `Blow` as the only available safe force carrier:
  - increase only `BaseMagnitude`, with separate bounded melee/missile caps;
  - preserve any stronger magnitude already supplied by Bannerlord or TOR;
  - repair only invalid, tiny, or downward `SwingDirection`;
  - do not activate ragdoll early;
  - do not inject a synthetic blow;
  - do not change damage, contact position, flags, health, or death timing;
  - do not schedule delayed/repeated force pulses.
- Skip the post-removal force queue on 1.2.12 because that version exposes no dedicated active-ragdoll force API.

## Expected 1.2.12 log

```text
Safe fatal-blow compatibility route magnitude=... missile=...
```

On 1.3+, the reflective dedicated route remains available:

```text
Safe ragdoll force route=Agent.ApplyForceOnRagdoll bone=... force=...
```

## Validation

- Branch is based directly on current `master`: two commits ahead, zero behind.
- Confirmed the 1.2.12 decompiled `Agent`, `IMBAgent`, `Skeleton`, and `GameEntityPhysicsExtensions` API surface.
- Confirmed no compile-time invocation of either 1.3-only Agent method remains.
- Confirmed the mixed `MathF.Max(float, int)` call is replaced with an explicit float cast.

This environment still lacks the user's Bannerlord 1.2.12 assemblies and Visual Studio/MSBuild setup, so the final compile and in-game result require local validation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ragdoll reactions for fatal melee and missile blows.
  * Added safer handling when impulse effects are unavailable, including fallback force and direction calculations.
  * Prevented invalid or non-finite impulse limits from affecting corpse physics.
  * Improved compatibility with supported game ragdoll behavior and handling of force-application failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->