### PR TITLE
Apply 1.2.12 force at the final native blow boundary

### DIFF
--- a/ExtremeRagdoll/ER_SafeLegacyDieImpulse.cs
+++ b/ExtremeRagdoll/ER_SafeLegacyDieImpulse.cs
@@ -9,43 +9,195 @@ using TaleWorlds.MountAndBlade;
 namespace ExtremeRagdoll
 {
     /// <summary>
-    /// Bannerlord 1.2.12 clamps Blow.BaseMagnitude to 1000 inside Agent.HandleBlow before
-    /// calling Agent.Die. Apply the bounded extreme value to Die's private Blow copy instead:
-    /// damage and hit callbacks have already completed, while the native death transition has
-    /// not started yet. This stays synchronous with the real fatal hit and never forces ragdoll.
+    /// Carries one lethal RegisterBlow context to Agent.HandleBlowAux on the same thread.
+    /// Bannerlord 1.2.12 calls HandleBlowAux only after damage callbacks and Agent.Die, so this
+    /// is the last managed boundary before native hit physics without taking ownership of the
+    /// animation-to-ragdoll transition.
     /// </summary>
-    [HarmonyPatch]
-    internal static class ER_SafeLegacyDieImpulsePatch
+    internal static class ER_LegacyFatalBlowContext
     {
-        private const float MeleeMagnitudeCap = 6000f;
-        private const float MissileMagnitudeCap = 3500f;
-        private const float MeleeMagnitudeFloor = 3000f;
-        private const float MissileMagnitudeFloor = 1800f;
-        private const float HardCapToMagnitudeUnits = 1000f;
-
-        private static readonly MethodBase[] Targets = FindTargets();
-
-        [HarmonyPrepare]
-        private static bool Prepare()
+        internal sealed class Frame
         {
-            if (Targets.Length != 0)
-                return true;
+            internal Agent Agent;
+            internal int AgentIndex;
+            internal Vec3 Direction;
+            internal float Magnitude;
+            internal bool Missile;
+        }
 
-            if (ER_Config.DebugLogging)
-                ER_Log.Info("Safe fatal Die impulse patch skipped: no compatible Agent.Die(Blow, ...) target");
+        [ThreadStatic]
+        private static Stack<Frame> _frames;
+
+        internal static int Depth => _frames?.Count ?? 0;
+
+        internal static void Arm(Agent agent, in Blow blow)
+        {
+            if (agent == null)
+                return;
+
+            var magnitude = ComputeMagnitude(in blow, out var missile);
+            if (magnitude <= 0f)
+                return;
+
+            var direction = ER_SafeDeathPipeline.ResolveDirection(agent, in blow);
+            if (!ER_Math.IsFinite(in direction) || direction.LengthSquared < ER_Math.DirectionTinySq)
+                return;
+
+            int agentIndex;
+            try { agentIndex = agent.Index; }
+            catch { agentIndex = -1; }
+
+            if (_frames == null)
+                _frames = new Stack<Frame>(4);
+
+            _frames.Push(new Frame
+            {
+                Agent = agent,
+                AgentIndex = agentIndex,
+                Direction = direction,
+                Magnitude = magnitude,
+                Missile = missile,
+            });
+        }
+
+        internal static bool TryConsume(Agent agent, out Frame frame)
+        {
+            frame = null;
+            var frames = _frames;
+            if (agent == null || frames == null || frames.Count == 0)
+                return false;
+
+            var top = frames.Peek();
+            if (!ReferenceEquals(top.Agent, agent))
+                return false;
+
+            frame = frames.Pop();
+            return true;
+        }
+
+        internal static void Trim(int depth)
+        {
+            var frames = _frames;
+            if (frames == null)
+                return;
+
+            if (depth < 0)
+                depth = 0;
+            while (frames.Count > depth)
+                frames.Pop();
+        }
+
+        private static float ComputeMagnitude(in Blow blow, out bool missile)
+        {
+            const float MeleeMagnitudeCap = 6000f;
+            const float MissileMagnitudeCap = 3500f;
+            const float MeleeMagnitudeFloor = 3000f;
+            const float MissileMagnitudeFloor = 1800f;
+            const float HardCapToMagnitudeUnits = 1000f;
+
+            missile = IsMissile(in blow);
+            var damage = MathF.Max(0f, (float)blow.InflictedDamage);
+            var cap = missile ? MissileMagnitudeCap : MeleeMagnitudeCap;
+
+            var configuredHardCap = ER_Config.CorpseImpulseHardCap;
+            if (!float.IsNaN(configuredHardCap) &&
+                !float.IsInfinity(configuredHardCap) &&
+                configuredHardCap > 0f)
+            {
+                cap = MathF.Min(cap, configuredHardCap * HardCapToMagnitudeUnits);
+            }
+            if (cap <= 0f)
+                return 0f;
+
+            var floor = missile ? MissileMagnitudeFloor : MeleeMagnitudeFloor;
+            if (floor > cap)
+                floor = cap;
+
+            var multiplier = MathF.Max(1f, ER_Config.ExtraForceMultiplier) *
+                             MathF.Max(1f, ER_Config.KnockbackMultiplier);
+            multiplier = MathF.Min(multiplier, 4f);
+
+            var damageScale = missile ? 12f : 20f;
+            var magnitude = (1000f + damage * damageScale) * multiplier;
+            if (magnitude < floor)
+                magnitude = floor;
+            if (magnitude > cap)
+                magnitude = cap;
+
+            return float.IsNaN(magnitude) || float.IsInfinity(magnitude) ? 0f : magnitude;
+        }
+
+        private static bool IsMissile(in Blow blow)
+        {
+            try
+            {
+                var flags = blow.BlowFlag.ToString();
+                return !string.IsNullOrEmpty(flags) &&
+                       flags.IndexOf("Missile", StringComparison.OrdinalIgnoreCase) >= 0;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Replaces the obsolete RegisterBlow compatibility mutation with a thread-local handoff.
+    /// The public Blow remains untouched; Bannerlord may perform its normal clamp and death work.
+    /// </summary>
+    [HarmonyPatch(typeof(ER_SafeDeathPipeline), nameof(ER_SafeDeathPipeline.ApplyLegacyFatalBlowFallback))]
+    internal static class ER_ArmLegacyFatalBlowContextPatch
+    {
+        [HarmonyPrefix]
+        [HarmonyPriority(Priority.First)]
+        private static bool Prefix(
+            [HarmonyArgument(0)] Agent agent,
+            [HarmonyArgument(1)] ref Blow blow)
+        {
+            ER_LegacyFatalBlowContext.Arm(agent, in blow);
             return false;
         }
+    }
+
+    /// <summary>
+    /// Bounds the lifetime of thread-local fatal-blow frames across nested/reentrant RegisterBlow
+    /// calls. The consumed frame normally disappears in HandleBlowAux; the finalizer removes any
+    /// unconsumed frame when Bannerlord exits early or throws.
+    /// </summary>
+    [HarmonyPatch]
+    internal static class ER_LegacyRegisterBlowContextLifetimePatch
+    {
+        private static readonly MethodBase[] Targets = FindTargets(nameof(Agent.RegisterBlow));
+
+        [HarmonyPrepare]
+        private static bool Prepare() => Targets.Length != 0;
 
         [HarmonyTargetMethods]
         private static IEnumerable<MethodBase> TargetMethods() => Targets;
 
-        private static MethodBase[] FindTargets()
+        [HarmonyPrefix]
+        [HarmonyPriority(Priority.First)]
+        private static void Prefix(out int __state)
+        {
+            __state = ER_LegacyFatalBlowContext.Depth;
+        }
+
+        [HarmonyFinalizer]
+        [HarmonyPriority(Priority.Last)]
+        private static Exception Finalizer(int __state, Exception __exception)
+        {
+            ER_LegacyFatalBlowContext.Trim(__state);
+            return __exception;
+        }
+
+        internal static MethodBase[] FindTargets(string methodName)
         {
             var targets = new List<MethodBase>();
             var blowType = typeof(Blow);
             foreach (var candidate in AccessTools.GetDeclaredMethods(typeof(Agent)))
             {
-                if (candidate == null || candidate.Name != "Die")
+                if (candidate == null || candidate.Name != methodName)
                     continue;
 
                 ParameterInfo[] parameters;
@@ -60,85 +212,78 @@ namespace ExtremeRagdoll
             }
             return targets.ToArray();
         }
+    }
+
+    /// <summary>
+    /// Applies the bounded fatal force to the actual Blow passed to native HandleBlowAux.
+    /// Agent.Die has already run, so the death animation/state transition remains engine-owned.
+    /// </summary>
+    [HarmonyPatch]
+    internal static class ER_SafeLegacyHandleBlowAuxImpulsePatch
+    {
+        private static readonly MethodBase[] Targets =
+            ER_LegacyRegisterBlowContextLifetimePatch.FindTargets("HandleBlowAux");
+
+        [HarmonyPrepare]
+        private static bool Prepare()
+        {
+            if (Targets.Length != 0)
+                return true;
+
+            if (ER_Config.DebugLogging)
+                ER_Log.Info("Safe final blow impulse patch skipped: no compatible Agent.HandleBlowAux(ref Blow) target");
+            return false;
+        }
+
+        [HarmonyTargetMethods]
+        private static IEnumerable<MethodBase> TargetMethods() => Targets;
 
         [HarmonyPrefix]
         [HarmonyPriority(Priority.Last)]
         [HarmonyAfter("TOR", "TOR_Core")]
         private static void Prefix(Agent __instance, [HarmonyArgument(0)] ref Blow blow)
         {
-            if (__instance == null || ER_ActiveRagdollImpulse.HasAgentForceRoute)
+            if (!ER_LegacyFatalBlowContext.TryConsume(__instance, out var frame))
+                return;
+
+            float health;
+            try { health = __instance.Health; }
+            catch { return; }
+            if (float.IsNaN(health) || float.IsInfinity(health) || health > 0f)
                 return;
 
             var originalMagnitude = blow.BaseMagnitude;
             if (float.IsNaN(originalMagnitude) || float.IsInfinity(originalMagnitude) || originalMagnitude < 0f)
                 originalMagnitude = 0f;
 
-            var damage = MathF.Max(0f, (float)blow.InflictedDamage);
-            var missile = IsMissile(in blow);
-
-            var cap = missile ? MissileMagnitudeCap : MeleeMagnitudeCap;
-            var configuredHardCap = ER_Config.CorpseImpulseHardCap;
-            if (!float.IsNaN(configuredHardCap) &&
-                !float.IsInfinity(configuredHardCap) &&
-                configuredHardCap > 0f)
-            {
-                cap = MathF.Min(cap, configuredHardCap * HardCapToMagnitudeUnits);
-            }
-            if (cap <= 0f)
-                return;
-
-            var floor = missile ? MissileMagnitudeFloor : MeleeMagnitudeFloor;
-            if (floor > cap)
-                floor = cap;
-
-            var multiplier = MathF.Max(1f, ER_Config.ExtraForceMultiplier) *
-                             MathF.Max(1f, ER_Config.KnockbackMultiplier);
-            multiplier = MathF.Min(multiplier, 4f);
-
-            var damageScale = missile ? 12f : 20f;
-            var sourceMagnitude = 1000f + damage * damageScale;
-            var desiredMagnitude = sourceMagnitude * multiplier;
-            if (desiredMagnitude < floor)
-                desiredMagnitude = floor;
-            if (desiredMagnitude > cap)
-                desiredMagnitude = cap;
-
-            // Preserve all values supplied by a stronger Die prefix. Only add our matching
-            // KnockBack flag/direction when this patch actually supplies the winning magnitude.
-            if (desiredMagnitude <= originalMagnitude)
+            // Preserve all values supplied by a stronger native-boundary prefix.
+            if (frame.Magnitude <= originalMagnitude)
             {
                 if (ER_Config.DebugLogging)
-                    ER_Log.Info($"Safe fatal Die impulse preserved stronger external magnitude={originalMagnitude:0}");
+                {
+                    ER_Log.Info(
+                        $"Safe final blow impulse preserved stronger external magnitude={originalMagnitude:0} " +
+                        $"Agent#{frame.AgentIndex}");
+                }
                 return;
             }
 
-            blow.BaseMagnitude = desiredMagnitude;
+            var direction = ER_DeathBlastBehavior.FinalizeImpulseDir(
+                frame.Direction,
+                ER_Config.CorpseLaunchMaxUpFraction);
+            if (!ER_Math.IsFinite(in direction) || direction.LengthSquared < ER_Math.DirectionTinySq)
+                direction = ER_SafeDeathPipeline.ResolveDirection(__instance, in blow);
 
-            // KnockBack is applied only to Die's by-value Blow copy. It cannot cause a living
-            // hit reaction or alter Agent.HandleBlowAux after Die returns. Do not add KnockDown:
-            // native death animation/ragdoll selection remains Bannerlord's responsibility.
+            blow.BaseMagnitude = frame.Magnitude;
             blow.BlowFlag |= BlowFlags.KnockBack;
-            blow.SwingDirection = ER_SafeDeathPipeline.ResolveDirection(__instance, in blow);
+            blow.SwingDirection = direction;
 
             if (ER_Config.DebugLogging)
             {
                 ER_Log.Info(
-                    $"Safe fatal Die impulse original={originalMagnitude:0} applied={blow.BaseMagnitude:0} " +
-                    $"missile={missile} knockBack=True");
-            }
-        }
-
-        private static bool IsMissile(in Blow blow)
-        {
-            try
-            {
-                var flags = blow.BlowFlag.ToString();
-                return !string.IsNullOrEmpty(flags) &&
-                       flags.IndexOf("Missile", StringComparison.OrdinalIgnoreCase) >= 0;
-            }
-            catch
-            {
-                return false;
+                    $"Safe final HandleBlowAux impulse Agent#{frame.AgentIndex} " +
+                    $"original={originalMagnitude:0} applied={blow.BaseMagnitude:0} " +
+                    $"missile={frame.Missile} knockBack=True");
             }
         }
     }


### PR DESCRIPTION
## Runtime evidence

The latest game log shows the merged `Agent.Die` prefix executing and logging `applied=6000`, often many times, while the visible result remains ineffective. That log only proves the by-value Die copy changed.

Bannerlord 1.2.12's managed order is:

```csharp
Die(b, ...);              // Blow passed by value
HandleBlowAux(ref b);     // original local Blow passed to native hit physics
```

The merged patch modified only the copy received by `Die`; after it returned, `HandleBlowAux(ref b)` still received the original/clamped blow. This explains the successful-looking log with vanilla physics.

## Fix

Replace the `Agent.Die` prefix with a synchronous handoff from the existing lethal `RegisterBlow` compatibility hook to private `Agent.HandleBlowAux(ref Blow)`:

- Do not mutate the public fatal blow before Bannerlord processes damage and death.
- Capture agent identity, safe direction, missile state, and bounded desired magnitude.
- Let `Agent.Die` run normally and own death animation/state selection.
- Apply the magnitude and `KnockBack` only to the actual `ref Blow` entering native `HandleBlowAux` immediately afterward.
- Do not add `KnockDown`.
- Do not activate/wake/tick/teleport ragdoll, inject another blow, alter damage/health/contact, or schedule delayed/repeated force.
- Preserve equal or stronger values supplied by another final-boundary prefix.
- Use a thread-local stack plus RegisterBlow depth/finalizer cleanup so nested/reentrant hits cannot leak stale context.
- Gate reflected targets with `HarmonyPrepare` for unsupported game versions.
- Leave direct scripted `Agent.Die` calls untouched because Bannerlord 1.2.12 exposes no safe dedicated post-ragdoll force API.

## Expected log

A real combat kill should now contain:

```text
Safe final HandleBlowAux impulse Agent#... original=... applied=6000 missile=False knockBack=True
```

The previous lines should disappear:

```text
Safe fatal-blow compatibility route magnitude=2200 ...
Safe fatal Die impulse ...
```

## Validation

- Clean branch based on current `master`.
- One commit ahead, zero behind.
- Changes only `ER_SafeLegacyDieImpulse.cs`.
- No build/game CI is available; compilation and in-game reaction require local validation against Bannerlord 1.2.12/TOR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved fatal blow handling for more consistent knockback and impact direction.
  * Preserves stronger existing impact values instead of overwriting them.
  * Applies safer limits and validation to melee and missile impacts.
  * Improved handling of nested or repeated blow events to prevent unintended effects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->