### PR TITLE
Build Guided Arrow v1.1.6 autoguidance recovery

### DIFF
--- a/.github/workflows/build-guided-arrow-v1.1.6-autoguidance-recovery.yml
+++ b/.github/workflows/build-guided-arrow-v1.1.6-autoguidance-recovery.yml
@@ -1,0 +1,41 @@
+name: Build Guided Arrow v1.1.6 Autoguidance Recovery
+
+on:
+  pull_request:
+    branches: [ codex/ga115-flight-profiles ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build-and-validate:
+    runs-on: windows-latest
+    timeout-minutes: 60
+    steps:
+      - name: Checkout exact source payload
+        uses: actions/checkout@v4
+        with:
+          show-progress: false
+
+      - name: Build and validate Guided Arrow v1.1.6
+        shell: pwsh
+        run: |
+          ./tools/build-ga116-autoguidance-recovery.ps1 -OutputRoot "$env:RUNNER_TEMP\ga116-output"
+
+      - name: Upload complete diagnostics
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: GuidedArrow-v1.1.6-diagnostics
+          path: ${{ runner.temp }}\ga116-output\diagnostics
+          if-no-files-found: warn
+          retention-days: 7
+
+      - name: Upload compiled clean module
+        uses: actions/upload-artifact@v4
+        with:
+          name: GuidedArrow-v1.1.6-compiled
+          path: ${{ runner.temp }}\ga116-output\artifact
+          if-no-files-found: error
+          retention-days: 7

--- a/.github/workflows/build-guided-arrow-v1.1.6-autoguidance-recovery.yml
+++ b/.github/workflows/build-guided-arrow-v1.1.6-autoguidance-recovery.yml
@@ -12,6 +12,8 @@ jobs:
   build-and-validate:
     runs-on: windows-latest
     timeout-minutes: 60
+    outputs:
+      failure_message: ${{ steps.build.outputs.failure_message }}
     steps:
       - name: Checkout exact source payload
         uses: actions/checkout@v4
@@ -19,9 +21,17 @@ jobs:
           show-progress: false
 
       - name: Build and validate Guided Arrow v1.1.6
+        id: build
         shell: pwsh
         run: |
-          ./tools/build-ga116-autoguidance-recovery.ps1 -OutputRoot "$env:RUNNER_TEMP\ga116-output"
+          try {
+            ./tools/build-ga116-autoguidance-recovery.ps1 -OutputRoot "$env:RUNNER_TEMP\ga116-output"
+          }
+          catch {
+            $message = $_.Exception.Message.Replace("`r", ' ').Replace("`n", ' ')
+            "failure_message=$message" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+            throw
+          }
 
       - name: Upload complete diagnostics
         if: always()
@@ -39,3 +49,18 @@ jobs:
           path: ${{ runner.temp }}\ga116-output\artifact
           if-no-files-found: error
           retention-days: 7
+
+  concise-result:
+    needs: build-and-validate
+    if: always()
+    runs-on: windows-latest
+    steps:
+      - name: Report build result
+        shell: pwsh
+        env:
+          RESULT: ${{ needs.build-and-validate.result }}
+          FAILURE_MESSAGE: ${{ needs.build-and-validate.outputs.failure_message }}
+        run: |
+          Write-Host "BUILD_RESULT=$env:RESULT"
+          Write-Host "FAILURE_MESSAGE=$env:FAILURE_MESSAGE"
+          if ($env:RESULT -ne 'success') { exit 1 }

--- a/tools/build-ga116-autoguidance-recovery.ps1
+++ b/tools/build-ga116-autoguidance-recovery.ps1
@@ -128,7 +128,7 @@ try {
             $dll = Join-Path $compiled 'GuidedArrow.dll'
             $pdb = Join-Path $compiled 'GuidedArrow.pdb'
             $assembly = [Reflection.AssemblyName]::GetAssemblyName($dll)
-            if ($assembly.Version.ToString() -ne '1.1.6.0') { throw "Unexpected assembly version for $reference: $($assembly.Version)" }
+            if ($assembly.Version.ToString() -ne '1.1.6.0') { throw "Unexpected assembly version for ${reference}: $($assembly.Version)" }
             $matrixResults.Add("$reference=PASS")
 
             if ($reference -eq '1.3.15.110062') {

--- a/tools/build-ga116-autoguidance-recovery.ps1
+++ b/tools/build-ga116-autoguidance-recovery.ps1
@@ -1,0 +1,191 @@
+param(
+    [Parameter(Mandatory = $true)]
+    [string] $OutputRoot
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+$repo = (Get-Location).Path
+$baseOutput = Join-Path $OutputRoot 'v1.1.5-baseline'
+$diag = Join-Path $OutputRoot 'diagnostics'
+$artifact = Join-Path $OutputRoot 'artifact'
+New-Item -ItemType Directory $baseOutput,$diag,$artifact -Force | Out-Null
+
+function Assert-FileHash([string] $Path, [string] $Expected, [string] $Label) {
+    if (!(Test-Path -LiteralPath $Path)) { throw "$Label missing: $Path" }
+    $actual = (Get-FileHash -LiteralPath $Path -Algorithm SHA256).Hash.ToLowerInvariant()
+    if ($actual -ne $Expected) { throw "$Label hash mismatch: expected $Expected, observed $actual" }
+}
+
+function Write-LfFile([string] $Source, [string] $Destination) {
+    $text = [IO.File]::ReadAllText($Source).Replace("`r`n", "`n")
+    [IO.File]::WriteAllText($Destination, $text, [Text.UTF8Encoding]::new($false))
+}
+
+try {
+    & (Join-Path $repo 'tools/build-ga115-flight-profiles.ps1') -OutputRoot $baseOutput
+
+    $sourceRoot = Join-Path $env:RUNNER_TEMP 'ga115-build/source'
+    $gaSource = Join-Path $sourceRoot 'GuidedArrow'
+    if (!(Test-Path -LiteralPath $gaSource)) { throw "Reconstructed v1.1.5 source missing: $gaSource" }
+
+    Assert-FileHash (Join-Path $gaSource 'Source/GuidedArrow.csproj') 'b90bd0d3b93df6251a9820a6498371a47f99f17a98c0587e801bcbc942abdee1' 'v1.1.5 project'
+    Assert-FileHash (Join-Path $gaSource 'Source/GuidedArrowBehavior.cs') '9ea60734372dbba1280ffec3c778689438cb6e6caaacee70e0f589f722f42da4' 'v1.1.5 behavior'
+    Assert-FileHash (Join-Path $gaSource 'Source/Settings.cs') '308079e86f24e845385ed29033c54f8d5b5bebe55f1b77d108cc441d148b36f8' 'v1.1.5 settings'
+    Assert-FileHash (Join-Path $gaSource 'Source/SubModule.cs') '31103cc6fc3d192e5164ef3ca0d2128c9026ab32c81cc45d8e9c3ffe73601bae' 'v1.1.5 SubModule.cs'
+    Assert-FileHash (Join-Path $gaSource 'SubModule.xml') 'c5fff278e1da74702318f5bdec942e11a1d99fc2216f1f3f25416276d08799e0' 'v1.1.5 SubModule.xml'
+
+    $patch = Join-Path $env:RUNNER_TEMP 'ga116-autoguidance-recovery.patch'
+    Write-LfFile (Join-Path $repo 'tools/ga116-autoguidance-recovery.patch') $patch
+    Assert-FileHash $patch '11feb9e64e9a12307c91edda6fce119d0e016753a9eaf6772c62680c502d5d51' 'v1.1.6 patch'
+
+    Push-Location $sourceRoot
+    try {
+        git apply --check --verbose --unsafe-paths $patch
+        if ($LASTEXITCODE -ne 0) { throw 'v1.1.6 patch applicability check failed' }
+        git apply --verbose --unsafe-paths $patch
+        if ($LASTEXITCODE -ne 0) { throw 'v1.1.6 patch application failed' }
+        git diff --check
+        if ($LASTEXITCODE -ne 0) { throw 'v1.1.6 patch introduced whitespace errors' }
+    }
+    finally { Pop-Location }
+
+    Assert-FileHash (Join-Path $gaSource 'Source/GuidedArrow.csproj') '128378a20b40d17aa6f25ce57ea08294f237e56ffad11f958b8edc70e2dab477' 'v1.1.6 project'
+    Assert-FileHash (Join-Path $gaSource 'Source/GuidedArrowBehavior.cs') '7823433022369c96e7fe7f2ec8097e9d11cc1d311be93cd640a67aa76d020db0' 'v1.1.6 behavior'
+    Assert-FileHash (Join-Path $gaSource 'Source/Settings.cs') '308079e86f24e845385ed29033c54f8d5b5bebe55f1b77d108cc441d148b36f8' 'unchanged settings'
+    Assert-FileHash (Join-Path $gaSource 'Source/SubModule.cs') '31103cc6fc3d192e5164ef3ca0d2128c9026ab32c81cc45d8e9c3ffe73601bae' 'unchanged SubModule.cs'
+    Assert-FileHash (Join-Path $gaSource 'SubModule.xml') 'c68e927eede1060c46ebc826a7c96bb7db763a1287b34aa823ccdbc634b41fb7' 'v1.1.6 SubModule.xml'
+
+    $behavior = [IO.File]::ReadAllText((Join-Path $gaSource 'Source/GuidedArrowBehavior.cs'))
+    foreach ($marker in @(
+        'GuidanceRecoveryActive',
+        'GuidanceForceDirectIntercept',
+        'GetAutoguidanceRecoveryReengageReserve',
+        'ShouldForceDirectTerminalIntercept',
+        'A decorative profile waypoint may become infeasible',
+        'float demandedReserve = Math.Max(0f, reserve) * Clamp(turnDemand, 0f, 1f);'
+    )) {
+        if (!$behavior.Contains($marker)) { throw "Missing v1.1.6 behavior gate: $marker" }
+    }
+    if ($behavior.Contains('bestFallbackIndex')) { throw 'Unreachable-target fallback was reintroduced' }
+
+    $settings = [IO.File]::ReadAllText((Join-Path $gaSource 'Source/Settings.cs'))
+    if (!$settings.Contains('public string AutoguidanceHotkeyName { get; set; } = "Ctrl+G";')) { throw 'MCM hotkey identity changed' }
+    if (!$settings.Contains('[SettingPropertyDropdown("Autoguidance Flight Profile", Order = 14')) { throw 'Flight profile setting changed' }
+
+    python (Join-Path $repo 'tools/test-ga116-guidance.py') 2>&1 | Tee-Object -FilePath (Join-Path $diag 'GUIDANCE_GEOMETRY_TESTS.txt')
+    if ($LASTEXITCODE -ne 0) { throw 'Guidance geometry regressions failed' }
+
+    @(
+        'SOURCE_INTEGRITY=PASS',
+        'PATCH_APPLICABILITY=PASS',
+        'MCM_SCHEMA_PRESERVED=PASS',
+        'UNREACHABLE_FALLBACK_REMOVED=PASS',
+        'BEHAVIOR_SHA256=7823433022369c96e7fe7f2ec8097e9d11cc1d311be93cd640a67aa76d020db0',
+        'PROJECT_SHA256=128378a20b40d17aa6f25ce57ea08294f237e56ffad11f958b8edc70e2dab477',
+        'SETTINGS_SHA256=308079e86f24e845385ed29033c54f8d5b5bebe55f1b77d108cc441d148b36f8'
+    ) | Set-Content (Join-Path $diag 'SOURCE_VERIFICATION.txt') -Encoding utf8
+
+    $references = @(
+        '1.3.15.110062',
+        '1.4.0.112726-beta',
+        '1.4.1.113228-beta',
+        '1.4.2.113809-beta',
+        '1.4.3.114169-beta',
+        '1.4.4.114449-beta',
+        '1.4.5.115026',
+        '1.4.6.115628',
+        '1.4.7.117484'
+    )
+    $project = Join-Path $gaSource 'Source/GuidedArrow.csproj'
+    $originalProject = [IO.File]::ReadAllText($project)
+    $matrixResults = New-Object System.Collections.Generic.List[string]
+    $productionDll = $null
+    $productionPdb = $null
+
+    try {
+        foreach ($reference in $references) {
+            $safeReference = $reference.Replace('.', '_').Replace('-', '_')
+            $retargeted = $originalProject.Replace('1.3.15.110062', $reference)
+            [IO.File]::WriteAllText($project, $retargeted, [Text.UTF8Encoding]::new($false))
+
+            foreach ($folder in @('bin','obj')) {
+                $path = Join-Path (Join-Path $gaSource 'Source') $folder
+                if (Test-Path -LiteralPath $path) { Remove-Item -LiteralPath $path -Recurse -Force }
+            }
+
+            Push-Location (Join-Path $gaSource 'Source')
+            try {
+                dotnet restore GuidedArrow.csproj --nologo --force-evaluate 2>&1 | Tee-Object -FilePath (Join-Path $diag "RESTORE_$safeReference.txt")
+                if ($LASTEXITCODE -ne 0) { throw "Restore failed for Bannerlord $reference" }
+                dotnet build GuidedArrow.csproj -c Release --no-restore --nologo /p:ContinuousIntegrationBuild=true /p:Deterministic=true 2>&1 | Tee-Object -FilePath (Join-Path $diag "COMPILER_$safeReference.txt")
+                if ($LASTEXITCODE -ne 0) { throw "Build failed for Bannerlord $reference" }
+            }
+            finally { Pop-Location }
+
+            $compiled = Join-Path $gaSource 'Source/bin/Release/net472'
+            $dll = Join-Path $compiled 'GuidedArrow.dll'
+            $pdb = Join-Path $compiled 'GuidedArrow.pdb'
+            $assembly = [Reflection.AssemblyName]::GetAssemblyName($dll)
+            if ($assembly.Version.ToString() -ne '1.1.6.0') { throw "Unexpected assembly version for $reference: $($assembly.Version)" }
+            $matrixResults.Add("$reference=PASS")
+
+            if ($reference -eq '1.3.15.110062') {
+                $productionDll = Join-Path $artifact 'GuidedArrow.dll'
+                $productionPdb = Join-Path $artifact 'GuidedArrow.pdb'
+                Copy-Item -LiteralPath $dll -Destination $productionDll -Force
+                Copy-Item -LiteralPath $pdb -Destination $productionPdb -Force
+            }
+        }
+    }
+    finally {
+        [IO.File]::WriteAllText($project, $originalProject, [Text.UTF8Encoding]::new($false))
+    }
+
+    if ($null -eq $productionDll -or !(Test-Path -LiteralPath $productionDll)) { throw 'Production DLL was not captured' }
+    if ($null -eq $productionPdb -or !(Test-Path -LiteralPath $productionPdb)) { throw 'Production PDB was not captured' }
+    $matrixResults | Set-Content (Join-Path $diag 'COMPATIBILITY_MATRIX.txt') -Encoding utf8
+
+    $module = Join-Path $artifact 'GuidedArrow'
+    $moduleSource = Join-Path $module 'Source'
+    $moduleBin = Join-Path $module 'bin/Win64_Shipping_Client'
+    New-Item -ItemType Directory $moduleSource,$moduleBin -Force | Out-Null
+    Copy-Item -LiteralPath (Join-Path $gaSource 'SubModule.xml') -Destination $module -Force
+    Copy-Item -LiteralPath (Join-Path $gaSource 'Source/GuidedArrow.csproj') -Destination $moduleSource -Force
+    Copy-Item -LiteralPath (Join-Path $gaSource 'Source/GuidedArrowBehavior.cs') -Destination $moduleSource -Force
+    Copy-Item -LiteralPath (Join-Path $gaSource 'Source/Settings.cs') -Destination $moduleSource -Force
+    Copy-Item -LiteralPath (Join-Path $gaSource 'Source/SubModule.cs') -Destination $moduleSource -Force
+    if (Test-Path -LiteralPath (Join-Path $gaSource 'GUI')) {
+        Copy-Item -LiteralPath (Join-Path $gaSource 'GUI') -Destination $module -Recurse -Force
+    }
+    Copy-Item -LiteralPath $productionDll -Destination $moduleBin -Force
+    Copy-Item -LiteralPath $productionPdb -Destination $moduleBin -Force
+
+    Copy-Item -LiteralPath $patch -Destination (Join-Path $artifact 'GuidedArrow-v1.1.5-to-v1.1.6.patch') -Force
+    Copy-Item -LiteralPath (Join-Path $repo 'tools/test-ga116-guidance.py') -Destination $artifact -Force
+
+    $assembly = [Reflection.AssemblyName]::GetAssemblyName($productionDll)
+    $versionInfo = (Get-Item -LiteralPath $productionDll).VersionInfo
+    @(
+        "AssemblyVersion=$($assembly.Version)",
+        "FileVersion=$($versionInfo.FileVersion)",
+        "ProductVersion=$($versionInfo.ProductVersion)",
+        "DLL_SHA256=$((Get-FileHash -LiteralPath $productionDll -Algorithm SHA256).Hash.ToLowerInvariant())",
+        "PDB_SHA256=$((Get-FileHash -LiteralPath $productionPdb -Algorithm SHA256).Hash.ToLowerInvariant())",
+        'PRODUCTION_REFERENCE=1.3.15.110062',
+        'SUPPORTED_RANGE=1.3.15-1.4.7'
+    ) | Set-Content (Join-Path $artifact 'BUILD_METADATA.txt') -Encoding utf8
+
+    'BUILD_STATUS=SUCCESS' | Set-Content (Join-Path $diag 'BUILD_STATUS.txt') -Encoding utf8
+    Copy-Item -Path (Join-Path $diag '*') -Destination $artifact -Force
+}
+catch {
+    @(
+        'BUILD_STATUS=FAILURE',
+        "ERROR_TYPE=$($_.Exception.GetType().FullName)",
+        "ERROR_MESSAGE=$($_.Exception.Message)",
+        "STACK=$($_.ScriptStackTrace)"
+    ) | Set-Content (Join-Path $diag 'BUILD_STATUS.txt') -Encoding utf8
+    throw
+}

--- a/tools/ga116-autoguidance-recovery.patch
+++ b/tools/ga116-autoguidance-recovery.patch
@@ -1,0 +1,324 @@
+diff --git a/GuidedArrow/Source/GuidedArrow.csproj b/GuidedArrow/Source/GuidedArrow.csproj
+index 6aaca32..fd84872 100644
+--- a/GuidedArrow/Source/GuidedArrow.csproj
++++ b/GuidedArrow/Source/GuidedArrow.csproj
+@@ -6,9 +6,9 @@
+     <AssemblyName>GuidedArrow</AssemblyName>
+     <RootNamespace>GuidedArrow</RootNamespace>
+     <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
+-    <Version>1.1.5</Version>
+-    <FileVersion>1.1.5.0</FileVersion>
+-    <AssemblyVersion>1.1.5.0</AssemblyVersion>
++    <Version>1.1.6</Version>
++    <FileVersion>1.1.6.0</FileVersion>
++    <AssemblyVersion>1.1.6.0</AssemblyVersion>
+     <Deterministic>true</Deterministic>
+     <DebugType>pdbonly</DebugType>
+     <Optimize>true</Optimize>
+diff --git a/GuidedArrow/Source/GuidedArrowBehavior.cs b/GuidedArrow/Source/GuidedArrowBehavior.cs
+index e39eca3..b070811 100644
+--- a/GuidedArrow/Source/GuidedArrowBehavior.cs
++++ b/GuidedArrow/Source/GuidedArrowBehavior.cs
+@@ -111,6 +111,13 @@ namespace GuidedArrow
+             public int GuidanceConfiguredProfileIndex = -1;
+             public int GuidanceResolvedProfileIndex;
+             public bool GuidanceResolvedProfileValid;
++            // When the target/waypoint falls inside the missile's current curvature envelope,
++            // suspend pursuit and coast until enough separation exists for a clean re-entry.
++            // Recovery is latched to prevent frame-to-frame engage/disengage oscillation.
++            public bool GuidanceRecoveryActive;
++            // Once a recovery manoeuvre was required, decorative profile staging is disabled for
++            // this target. The missile completes the recovered approach as a direct head intercept.
++            public bool GuidanceForceDirectIntercept;
+             public float EstimatedGravityZ = -9.81f;
+             public Vec3 LastCommandedVelocity;
+             public bool LastCommandedVelocityValid;
+@@ -186,6 +193,8 @@ namespace GuidedArrow
+         private const float AutoguidanceReacquireInterval = 0.15f;
+         private const float AutoguidanceTerrainSampleInterval = 0.08f;
+         private const float AutoguidanceMinimumPostImpactTravel = 8f;
++        private const float AutoguidanceMinimumReachabilityReserve = 0.75f;
++        private const float AutoguidanceRecoveryReserve = 2f;
+         private const float DefaultGravityZ = -9.81f;
+         private const float Tiny = 1e-6f;
+ 
+@@ -2023,6 +2032,8 @@ namespace GuidedArrow
+             tracked.GuidanceTerrainSampleCountdown = 0f;
+             tracked.GuidanceCruiseGroundZ = 0f;
+             tracked.GuidanceCruiseGroundValid = false;
++            tracked.GuidanceRecoveryActive = false;
++            tracked.GuidanceForceDirectIntercept = false;
+         }
+ 
+         private void ShowAutoguidanceMessage(string message)
+@@ -2292,8 +2303,7 @@ namespace GuidedArrow
+             float bestSafeReachableScore = float.PositiveInfinity;
+             int bestUnsafeReachableIndex = -1;
+             float bestUnsafeReachableScore = float.PositiveInfinity;
+-            int bestFallbackIndex = -1;
+-            float bestFallbackScore = float.PositiveInfinity;
++            float reachabilityReserve = GetAutoguidanceReachabilityReserve(effectiveTurnRadius, speed, 0f);
+ 
+             for (int i = 0; i < _autoguidanceRankCandidates.Count; i++)
+             {
+@@ -2316,9 +2326,12 @@ namespace GuidedArrow
+                 float referenceDot = Clamp(Dot(referenceDirection, targetDirection), -1f, 1f);
+                 float referenceAngle = (float)Math.Acos(referenceDot);
+ 
+-                float requiredDistance = EstimateMinimumReachableDistance(effectiveTurnRadius, forwardAngle);
+-                float reachabilityShortfall = Math.Max(0f, requiredDistance - distance);
+-                bool reachable = reachabilityShortfall <= 0.001f;
++                bool reachable = IsAutoguidanceWaypointReachable(
++                    position,
++                    forward,
++                    targetHead,
++                    effectiveTurnRadius,
++                    reachabilityReserve);
+ 
+                 EvaluateAutoguidanceApproachGeometry(
+                     tracked,
+@@ -2367,28 +2380,17 @@ namespace GuidedArrow
+                         bestUnsafeReachableIndex = i;
+                     }
+                 }
+-                else
+-                {
+-                    // Only used when no currently reachable target exists. Prefer the smallest
+-                    // curvature shortfall, while still avoiding a severe downward exit when another
+-                    // recovery candidate offers materially safer geometry.
+-                    float unsafePenalty = postImpactSafe ? 0f : effectiveTurnRadius * 2f;
+-                    float fallbackScore = reachabilityShortfall * 12f + forwardAngle * effectiveTurnRadius + distance * 0.02f + unsafePenalty;
+-                    if (selection == 1)
+-                        fallbackScore += referenceAngle * 4f;
+-                    if (fallbackScore < bestFallbackScore)
+-                    {
+-                        bestFallbackScore = fallbackScore;
+-                        bestFallbackIndex = i;
+-                    }
+-                }
++                // Unreachable candidates are deliberately not assigned. Steering toward a live
++                // target inside the current curvature envelope creates a stable pure-pursuit orbit.
++                // The missile instead keeps its current flight path and the throttled acquisition
++                // pass may lock the target once the geometry becomes feasible.
+             }
+ 
+             if (bestSafeReachableIndex >= 0)
+                 return bestSafeReachableIndex;
+             if (bestUnsafeReachableIndex >= 0)
+                 return bestUnsafeReachableIndex;
+-            return bestFallbackIndex;
++            return -1;
+         }
+ 
+         private void EvaluateAutoguidanceApproachGeometry(
+@@ -2666,15 +2668,85 @@ namespace GuidedArrow
+             Vec3 currentDirection,
+             Vec3 waypoint,
+             float effectiveTurnRadius)
++        {
++            // Existing profile-shaping checks intentionally retain their original zero-reserve
++            // semantics. Safety hysteresis is applied only at target acquisition and at the live
++            // interception boundary where engage/disengage oscillation can create an orbit.
++            return IsAutoguidanceWaypointReachable(
++                projectilePosition,
++                currentDirection,
++                waypoint,
++                effectiveTurnRadius,
++                0f);
++        }
++
++        private static bool IsAutoguidanceWaypointReachable(
++            Vec3 projectilePosition,
++            Vec3 currentDirection,
++            Vec3 waypoint,
++            float effectiveTurnRadius,
++            float reserve)
+         {
+             Vec3 toWaypoint = waypoint - projectilePosition;
+             float distance = toWaypoint.Length;
+-            if (!IsFinite(toWaypoint) || !IsFinite(distance) || distance <= 0.1f)
++            if (!IsFinite(toWaypoint) || !IsFinite(distance))
+                 return false;
++            if (distance <= 0.35f)
++                return true;
+ 
+             Vec3 waypointDirection = toWaypoint / distance;
+             float angle = (float)Math.Acos(Clamp(Dot(currentDirection, waypointDirection), -1f, 1f));
+-            return distance + 0.001f >= EstimateMinimumReachableDistance(effectiveTurnRadius, angle);
++            float requiredDistance = EstimateMinimumReachableDistance(effectiveTurnRadius, angle);
++            // Reserve only the part of the envelope that is actually consumed by turning. A target
++            // already on the current flight line remains reachable at close range; applying a fixed
++            // distance reserve there would make the controller stop steering immediately before impact.
++            float turnDemand = (float)Math.Sin(Math.Min(angle, (float)Math.PI * 0.5f));
++            float demandedReserve = Math.Max(0f, reserve) * Clamp(turnDemand, 0f, 1f);
++            return distance + 0.001f >= requiredDistance + demandedReserve;
++        }
++
++        private static float GetAutoguidanceReachabilityReserve(
++            float effectiveTurnRadius,
++            float speed,
++            float dt)
++        {
++            float radiusReserve = Math.Max(
++                AutoguidanceMinimumReachabilityReserve,
++                Math.Max(0.1f, effectiveTurnRadius) * 0.08f);
++            float frameTravelReserve = IsFinite(speed) && IsFinite(dt) && speed > 0f && dt > 0f
++                ? speed * dt * 1.5f
++                : 0f;
++            return radiusReserve + frameTravelReserve;
++        }
++
++        private static float GetAutoguidanceRecoveryReengageReserve(
++            float effectiveTurnRadius,
++            float speed,
++            float dt)
++        {
++            float ordinaryReserve = GetAutoguidanceReachabilityReserve(effectiveTurnRadius, speed, dt);
++            float recoveryReserve = Math.Max(
++                AutoguidanceRecoveryReserve,
++                Math.Max(0.1f, effectiveTurnRadius) * 0.35f);
++            return Math.Max(ordinaryReserve, recoveryReserve);
++        }
++
++        private static bool ShouldForceDirectTerminalIntercept(
++            Vec3 projectilePosition,
++            Vec3 currentDirection,
++            Vec3 predictedHead,
++            float effectiveTurnRadius)
++        {
++            Vec3 toHead = predictedHead - projectilePosition;
++            float distance = toHead.Length;
++            if (!IsFinite(toHead) || !IsFinite(distance) || distance <= 0.35f)
++                return true;
++
++            Vec3 headDirection = toHead / distance;
++            float angle = (float)Math.Acos(Clamp(Dot(currentDirection, headDirection), -1f, 1f));
++            float requiredDistance = EstimateMinimumReachableDistance(effectiveTurnRadius, angle);
++            float terminalReserve = Math.Max(6f, effectiveTurnRadius * 0.45f);
++            return distance <= requiredDistance + terminalReserve;
+         }
+ 
+         private static float GetLoftedArcDescentAngle(Vec3 targetHead, Vec3 targetBase)
+@@ -2763,6 +2835,8 @@ namespace GuidedArrow
+             tracked.GuidanceTerrainSampleCountdown = 0f;
+             tracked.GuidanceCruiseGroundZ = 0f;
+             tracked.GuidanceCruiseGroundValid = false;
++            tracked.GuidanceRecoveryActive = false;
++            tracked.GuidanceForceDirectIntercept = false;
+             if (TryGetGuidanceHeadPosition(target, tracked.GuidanceHeadBoneIndex, out Vec3 head))
+             {
+                 tracked.GuidanceSmoothedHead = head;
+@@ -2896,18 +2970,85 @@ namespace GuidedArrow
+             }
+ 
+             Vec3 currentDirection = NormalizeSafe(projectileVelocity, predictedHead - projectilePosition);
++            float configuredRadius = Clamp(Settings.Instance?.MinimumTurnRadius ?? 24f, 3f, 120f);
++            float steeringMultiplier = GetAdaptiveSteeringMultiplier(speed);
++            float effectiveTurnRadius = configuredRadius / Math.Max(1f, steeringMultiplier);
++
++            if (tracked.GuidanceRecoveryActive)
++            {
++                float recoveryReserve = GetAutoguidanceRecoveryReengageReserve(
++                    effectiveTurnRadius,
++                    speed,
++                    safeDt);
++                if (!IsAutoguidanceWaypointReachable(
++                    projectilePosition,
++                    currentDirection,
++                    predictedHead,
++                    effectiveTurnRadius,
++                    recoveryReserve))
++                {
++                    // Keep the exact native missile untouched and coast on its current velocity.
++                    // This grows the available turn envelope without adding lift, speed or steering.
++                    return false;
++                }
++
++                tracked.GuidanceRecoveryActive = false;
++                tracked.GuidanceForceDirectIntercept = true;
++            }
++
+             Vec3 targetBase = GetAgentVisualPositionSafe(tracked.GuidanceTarget, predictedPhysicalHead - WorldUp * 0.95f);
+             targetBase.x += targetVelocity.x * interceptTime;
+             targetBase.y += targetVelocity.y * interceptTime;
+-            Vec3 aimPoint = ComputeAutoguidanceAimPoint(
+-                tracked,
+-                projectilePosition,
+-                currentDirection,
++            bool forceDirect = tracked.GuidanceForceDirectIntercept ||
++                ShouldForceDirectTerminalIntercept(
++                    projectilePosition,
++                    currentDirection,
++                    predictedHead,
++                    effectiveTurnRadius);
++            Vec3 aimPoint = forceDirect
++                ? predictedHead
++                : ComputeAutoguidanceAimPoint(
++                    tracked,
++                    projectilePosition,
++                    currentDirection,
++                    speed,
++                    predictedHead,
++                    predictedPhysicalHead,
++                    targetBase,
++                    safeDt);
++
++            float reachabilityReserve = GetAutoguidanceReachabilityReserve(
++                effectiveTurnRadius,
+                 speed,
+-                predictedHead,
+-                predictedPhysicalHead,
+-                targetBase,
+                 safeDt);
++            if (!IsAutoguidanceWaypointReachable(
++                projectilePosition,
++                currentDirection,
++                aimPoint,
++                effectiveTurnRadius,
++                reachabilityReserve))
++            {
++                // A decorative profile waypoint may become infeasible while the real head intercept
++                // remains reachable. Drop the staging path immediately instead of throwing away a
++                // valid attack window. Only coast when the physical intercept itself is unreachable.
++                if (!forceDirect && IsAutoguidanceWaypointReachable(
++                    projectilePosition,
++                    currentDirection,
++                    predictedHead,
++                    effectiveTurnRadius,
++                    reachabilityReserve))
++                {
++                    tracked.GuidanceForceDirectIntercept = true;
++                    aimPoint = predictedHead;
++                }
++                else
++                {
++                    tracked.GuidanceRecoveryActive = true;
++                    tracked.GuidanceForceDirectIntercept = true;
++                    return false;
++                }
++            }
++
+             Vec3 desiredDirection = NormalizeSafe(aimPoint - projectilePosition, predictedHead - projectilePosition);
+             ComputeSteeringAngularError(currentDirection, desiredDirection, out float desiredYaw, out float desiredPitch);
+ 
+@@ -2915,7 +3056,6 @@ namespace GuidedArrow
+             // before enforcing the physical turn-radius cap. Divide the controller's actual angular
+             // error by that multiplier so autonomous and manual modes reach the identical limiter with
+             // no hidden steering authority.
+-            float steeringMultiplier = GetAdaptiveSteeringMultiplier(speed);
+             yaw = desiredYaw / Math.Max(1f, steeringMultiplier);
+             pitch = desiredPitch / Math.Max(1f, steeringMultiplier);
+             return IsFinite(yaw) && IsFinite(pitch);
+diff --git a/GuidedArrow/SubModule.xml b/GuidedArrow/SubModule.xml
+index 2d909c2..dbb5b84 100644
+--- a/GuidedArrow/SubModule.xml
++++ b/GuidedArrow/SubModule.xml
+@@ -2,7 +2,7 @@
+ <Module>
+   <Name value="Guided Arrow" />
+   <Id value="GuidedArrow" />
+-  <Version value="v1.1.5" />
++  <Version value="v1.1.6" />
+   <DefaultModule value="false" />
+   <SingleplayerModule value="true" />
+   <MultiplayerModule value="false" />

--- a/tools/test-ga116-guidance.py
+++ b/tools/test-ga116-guidance.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+"""Deterministic geometry regressions for Guided Arrow v1.1.6.
+
+This is a controller-level model of the minimum-turn envelope and recovery state.
+It proves the reported stable pure-pursuit orbit exists in the old policy and that
+latched coast/re-entry breaks that orbit without granting extra turn authority.
+"""
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Tuple
+
+Vec2 = Tuple[float, float]
+CAPTURE_RADIUS = 0.35
+
+
+def clamp(value: float, minimum: float, maximum: float) -> float:
+    return max(minimum, min(maximum, value))
+
+
+def norm(v: Vec2) -> float:
+    return math.hypot(v[0], v[1])
+
+
+def normalized(v: Vec2) -> Vec2:
+    length = norm(v)
+    if length <= 1e-12:
+        raise AssertionError("zero-length vector")
+    return (v[0] / length, v[1] / length)
+
+
+def unsigned_angle(a: Vec2, b: Vec2) -> float:
+    return math.acos(clamp(a[0] * b[0] + a[1] * b[1], -1.0, 1.0))
+
+
+def minimum_reachable_distance(radius: float, heading_angle: float) -> float:
+    radius = max(0.1, radius)
+    heading_angle = clamp(heading_angle, 0.0, math.pi)
+    if heading_angle <= math.pi * 0.5:
+        return 2.0 * radius * math.sin(heading_angle)
+    return 2.0 * radius + radius * (heading_angle - math.pi * 0.5)
+
+
+def waypoint_reachable(position: Vec2, heading: Vec2, waypoint: Vec2, radius: float, reserve: float) -> bool:
+    offset = (waypoint[0] - position[0], waypoint[1] - position[1])
+    distance = norm(offset)
+    if distance <= CAPTURE_RADIUS:
+        return True
+    direction = normalized(offset)
+    angle = unsigned_angle(heading, direction)
+    required = minimum_reachable_distance(radius, angle)
+    turn_demand = math.sin(min(angle, math.pi * 0.5))
+    demanded_reserve = max(0.0, reserve) * clamp(turn_demand, 0.0, 1.0)
+    return distance + 0.001 >= required + demanded_reserve
+
+
+def rotate_towards(current: Vec2, desired: Vec2, maximum_angle: float) -> Vec2:
+    signed = math.atan2(
+        current[0] * desired[1] - current[1] * desired[0],
+        current[0] * desired[0] + current[1] * desired[1],
+    )
+    signed = clamp(signed, -maximum_angle, maximum_angle)
+    c = math.cos(signed)
+    s = math.sin(signed)
+    return (current[0] * c - current[1] * s, current[0] * s + current[1] * c)
+
+
+def point_segment_distance(point: Vec2, start: Vec2, end: Vec2) -> float:
+    delta = (end[0] - start[0], end[1] - start[1])
+    length_squared = delta[0] * delta[0] + delta[1] * delta[1]
+    if length_squared <= 1e-12:
+        return norm((point[0] - start[0], point[1] - start[1]))
+    t = clamp(
+        ((point[0] - start[0]) * delta[0] + (point[1] - start[1]) * delta[1]) / length_squared,
+        0.0,
+        1.0,
+    )
+    closest = (start[0] + delta[0] * t, start[1] + delta[1] * t)
+    return norm((point[0] - closest[0], point[1] - closest[1]))
+
+
+@dataclass
+class SimulationResult:
+    hit: bool
+    minimum_distance: float
+    recovery_entries: int
+    recovery_exits: int
+    elapsed: float
+
+
+def simulate(target: Vec2, *, fixed: bool, dt: float = 0.02, duration: float = 8.0) -> SimulationResult:
+    position = (0.0, 0.0)
+    heading = (1.0, 0.0)
+    radius = 24.0
+    speed = 70.0
+    recovery = False
+    entries = 0
+    exits = 0
+    minimum_distance = float("inf")
+
+    for step in range(int(duration / dt)):
+        offset = (target[0] - position[0], target[1] - position[1])
+        desired = normalized(offset)
+        steer = True
+
+        if fixed:
+            ordinary_reserve = max(0.75, radius * 0.08) + speed * dt * 1.5
+            recovery_reserve = max(ordinary_reserve, max(2.0, radius * 0.35))
+            if recovery:
+                if waypoint_reachable(position, heading, target, radius, recovery_reserve):
+                    recovery = False
+                    exits += 1
+                else:
+                    steer = False
+            elif not waypoint_reachable(position, heading, target, radius, ordinary_reserve):
+                recovery = True
+                entries += 1
+                steer = False
+
+        if steer:
+            heading = rotate_towards(heading, desired, (speed / radius) * dt)
+
+        previous = position
+        position = (position[0] + heading[0] * speed * dt, position[1] + heading[1] * speed * dt)
+        segment_distance = point_segment_distance(target, previous, position)
+        minimum_distance = min(minimum_distance, segment_distance)
+        if segment_distance <= CAPTURE_RADIUS:
+            return SimulationResult(True, minimum_distance, entries, exits, (step + 1) * dt)
+
+    return SimulationResult(False, minimum_distance, entries, exits, duration)
+
+
+def assert_source_gates(source: Path) -> None:
+    text = source.read_text(encoding="utf-8")
+    required = (
+        "GuidanceRecoveryActive",
+        "GuidanceForceDirectIntercept",
+        "GetAutoguidanceRecoveryReengageReserve",
+        "ShouldForceDirectTerminalIntercept",
+        "A decorative profile waypoint may become infeasible",
+        "float demandedReserve = Math.Max(0f, reserve) * Clamp(turnDemand, 0f, 1f);",
+    )
+    for marker in required:
+        assert marker in text, f"missing v1.1.6 source marker: {marker}"
+    assert "bestFallbackIndex" not in text, "unreachable-target fallback was reintroduced"
+
+
+def main() -> None:
+    source = Path(__file__).resolve().parent.parent / "GuidedArrow" / "Source" / "GuidedArrowBehavior.cs"
+    if source.exists():
+        assert_source_gates(source)
+
+    assert not waypoint_reachable((0.0, 0.0), (1.0, 0.0), (0.0, 20.0), 24.0, 0.0)
+    assert waypoint_reachable((0.0, 0.0), (1.0, 0.0), (2.0, 0.0), 24.0, 20.0)
+    assert waypoint_reachable((0.0, 0.0), (1.0, 0.0), (60.0, 0.0), 24.0, 4.0)
+    assert not waypoint_reachable((0.0, 0.0), (1.0, 0.0), (20.0, 30.0), 24.0, 4.0)
+
+    old = simulate((0.0, 20.0), fixed=False)
+    fixed = simulate((0.0, 20.0), fixed=True)
+    assert not old.hit and old.minimum_distance > 10.0, old
+    assert fixed.hit and fixed.elapsed < 5.0, fixed
+    assert fixed.recovery_entries == 1 and fixed.recovery_exits == 1, fixed
+
+    for target in ((10.0, 10.0), (-10.0, 10.0), (-20.0, 0.0), (20.0, 20.0), (-30.0, 5.0)):
+        result = simulate(target, fixed=True)
+        assert result.hit and result.elapsed < 6.0, (target, result)
+        assert result.recovery_entries <= 1 and result.recovery_exits <= 1, (target, result)
+
+    print("GUIDANCE_GEOMETRY_TESTS=PASS")
+    print(f"OLD_ORBIT_MIN_DISTANCE={old.minimum_distance:.6f}")
+    print(f"FIXED_INTERCEPT_SECONDS={fixed.elapsed:.6f}")
+    print(f"FIXED_RECOVERY_TRANSITIONS={fixed.recovery_entries + fixed.recovery_exits}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Temporary build-only PR against the exact v1.1.5 source branch. The final v1.1.6 patch removes unreachable-target fallback selection, adds latched curvature-envelope recovery, falls back from infeasible profile waypoints to a reachable direct head intercept, preserves close straight-line steering, and retains the existing speed/physics/turn cap. Deterministic orbit regressions passed. Exact final source compiled with 0 warnings / 0 errors against every supported Bannerlord reference from 1.3.15.110062 through 1.4.7.117484. Successful workflow run 30146362662; compiled artifact 8616145315; artifact digest sha256:de6983cad0bff06dfb60d02b4779140b364b0cebd698cf92f2324ec5a549f763. Production DLL SHA-256: feb8e8c6314e7347077276c682d01753cd7ddcfd28bfbe10a87d303d8824c120. Closed without merge after artifact retrieval and release packaging.