### PR TITLE
Build Guided Arrow v1.1.16 single-usage launch bridge

### DIFF
--- a/.github/workflows/build-guided-arrow-v1.1.16-single-usage-launch-bridge.yml
+++ b/.github/workflows/build-guided-arrow-v1.1.16-single-usage-launch-bridge.yml
@@ -1,0 +1,62 @@
+name: Build Guided Arrow v1.1.16 Single-Usage Launch Bridge
+
+on:
+  pull_request:
+    branches: [ codex/ga1115-release-base ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build-and-validate:
+    runs-on: windows-latest
+    timeout-minutes: 180
+    outputs:
+      failure_message: ${{ steps.build.outputs.failure_message }}
+    steps:
+      - name: Checkout exact payload
+        uses: actions/checkout@v4
+        with:
+          show-progress: false
+      - name: Build and validate Guided Arrow v1.1.16
+        id: build
+        shell: pwsh
+        run: |
+          try {
+            & ./tools/ga1116/run-complete-build.ps1
+          }
+          catch {
+            $message=$_.Exception.Message.Replace("`r",' ').Replace("`n",' ')
+            "failure_message=$message" | Out-File $env:GITHUB_OUTPUT -Append -Encoding utf8
+            throw
+          }
+      - name: Upload diagnostics
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: GuidedArrow-v1.1.16-diagnostics
+          path: ${{ runner.temp }}\ga1116-output\diagnostics
+          if-no-files-found: warn
+          retention-days: 7
+      - name: Upload compiled module
+        uses: actions/upload-artifact@v4
+        with:
+          name: GuidedArrow-v1.1.16-compiled
+          path: ${{ runner.temp }}\ga1116-output\artifact
+          if-no-files-found: error
+          retention-days: 7
+  concise-result:
+    needs: build-and-validate
+    if: always()
+    runs-on: windows-latest
+    steps:
+      - name: Report result
+        shell: pwsh
+        env:
+          RESULT: ${{ needs.build-and-validate.result }}
+          FAILURE_MESSAGE: ${{ needs.build-and-validate.outputs.failure_message }}
+        run: |
+          Write-Host "BUILD_RESULT=$env:RESULT"
+          Write-Host "FAILURE_MESSAGE=$env:FAILURE_MESSAGE"
+          if($env:RESULT -ne 'success'){exit 1}

--- a/.github/workflows/extract-guided-arrow-v1.1.16-engine-launch-source.yml
+++ b/.github/workflows/extract-guided-arrow-v1.1.16-engine-launch-source.yml
@@ -1,0 +1,74 @@
+name: Extract Guided Arrow v1.1.16 Engine Launch Source
+
+on:
+  pull_request:
+    branches: [ codex/ga1115-release-base ]
+
+permissions:
+  contents: read
+
+jobs:
+  extract-engine-source:
+    runs-on: windows-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout build payload
+        uses: actions/checkout@v4
+        with:
+          path: payload
+          show-progress: false
+      - name: Checkout decompiled Bannerlord source
+        uses: actions/checkout@v4
+        with:
+          repository: zzACzz/BannerlordCoopSpectator
+          ref: 7a2d021ff0f385ae90d527aa8032aa739f25c587
+          path: engine-source
+          sparse-checkout: |
+            .codex_tmp/decompiled_mountandblade/TaleWorlds.MountAndBlade/Mission.cs
+          sparse-checkout-cone-mode: false
+          show-progress: false
+      - name: Extract launch methods
+        shell: pwsh
+        run: |
+          $ErrorActionPreference='Stop'
+          $source=Join-Path $env:GITHUB_WORKSPACE 'engine-source/.codex_tmp/decompiled_mountandblade/TaleWorlds.MountAndBlade/Mission.cs'
+          if(!(Test-Path $source)){throw "Mission.cs missing: $source"}
+          $text=[IO.File]::ReadAllText($source)
+          function Extract-Method([string]$name){
+            $patterns=@("public Missile $name", "internal void $name", "private int $name", "public Mission.Missile $name")
+            $start=-1
+            foreach($pattern in $patterns){$start=$text.IndexOf($pattern,[StringComparison]::Ordinal);if($start -ge 0){break}}
+            if($start -lt 0){return "METHOD_NOT_FOUND=$name`r`n"}
+            $brace=$text.IndexOf('{',$start)
+            if($brace -lt 0){return "OPEN_BRACE_NOT_FOUND=$name`r`n"}
+            $depth=0;$inString=$false;$escape=$false;$end=-1
+            for($i=$brace;$i -lt $text.Length;$i++){
+              $c=$text[$i]
+              if($inString){
+                if($escape){$escape=$false;continue}
+                if($c -eq '\'){ $escape=$true; continue }
+                if($c -eq '"'){ $inString=$false }
+                continue
+              }
+              if($c -eq '"'){ $inString=$true; continue }
+              if($c -eq '{'){$depth++}
+              elseif($c -eq '}'){$depth--;if($depth -eq 0){$end=$i+1;break}}
+            }
+            if($end -lt 0){return "CLOSE_BRACE_NOT_FOUND=$name`r`n"}
+            return $text.Substring($start,$end-$start)+"`r`n"
+          }
+          $out=Join-Path $env:RUNNER_TEMP 'ga1116-engine-source'
+          New-Item -ItemType Directory -Path $out -Force|Out-Null
+          $report=@()
+          $report += Extract-Method 'AddCustomMissile'
+          $report += Extract-Method 'OnAgentShootMissile'
+          $report += Extract-Method 'AddMissileAux'
+          $report += Extract-Method 'MissileHitCallback'
+          [IO.File]::WriteAllText((Join-Path $out 'ENGINE_LAUNCH_SOURCE.txt'),($report -join "`r`n"),[Text.UTF8Encoding]::new($false))
+      - name: Upload engine source report
+        uses: actions/upload-artifact@v4
+        with:
+          name: GuidedArrow-v1.1.16-engine-launch-source
+          path: ${{ runner.temp }}\ga1116-engine-source\ENGINE_LAUNCH_SOURCE.txt
+          if-no-files-found: error
+          retention-days: 7

--- a/.github/workflows/inspect-guided-arrow-v1.1.16-damage-api.yml
+++ b/.github/workflows/inspect-guided-arrow-v1.1.16-damage-api.yml
@@ -1,0 +1,48 @@
+name: Inspect Guided Arrow v1.1.16 Damage API
+
+on:
+  pull_request:
+    branches: [ codex/ga1115-release-base ]
+
+permissions:
+  contents: read
+
+jobs:
+  inspect-damage-api:
+    runs-on: windows-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          show-progress: false
+      - name: Inspect combat API
+        shell: pwsh
+        run: |
+          $ErrorActionPreference='Stop'
+          $root=Join-Path $env:RUNNER_TEMP 'ga1116-damage-api'
+          New-Item -ItemType Directory -Path $root -Force|Out-Null
+          Copy-Item 'tools/ga1116/InspectDamageApi.cs' (Join-Path $root 'Program.cs')
+          @'
+          <Project Sdk="Microsoft.NET.Sdk">
+            <PropertyGroup>
+              <OutputType>Exe</OutputType>
+              <TargetFramework>net8.0</TargetFramework>
+              <ImplicitUsings>disable</ImplicitUsings>
+              <Nullable>disable</Nullable>
+            </PropertyGroup>
+            <ItemGroup>
+              <PackageReference Include="Mono.Cecil" Version="0.11.6" />
+              <PackageReference Include="Bannerlord.ReferenceAssemblies.Core" Version="1.3.15.110062" />
+            </ItemGroup>
+          </Project>
+          '@ | Set-Content -LiteralPath (Join-Path $root 'DamageInspect.csproj') -Encoding utf8
+          dotnet restore (Join-Path $root 'DamageInspect.csproj') --nologo
+          dotnet run --project (Join-Path $root 'DamageInspect.csproj') -c Release --no-restore 2>&1 | Tee-Object -FilePath (Join-Path $root 'DAMAGE_API.txt')
+      - name: Upload report
+        uses: actions/upload-artifact@v4
+        with:
+          name: GuidedArrow-v1.1.16-damage-api
+          path: ${{ runner.temp }}\ga1116-damage-api\DAMAGE_API.txt
+          if-no-files-found: error
+          retention-days: 7

--- a/.github/workflows/inspect-guided-arrow-v1.1.16-launch-il.yml
+++ b/.github/workflows/inspect-guided-arrow-v1.1.16-launch-il.yml
@@ -1,0 +1,48 @@
+name: Inspect Guided Arrow v1.1.16 Launch IL
+
+on:
+  pull_request:
+    branches: [ codex/ga1115-release-base ]
+
+permissions:
+  contents: read
+
+jobs:
+  inspect-launch-il:
+    runs-on: windows-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          show-progress: false
+      - name: Inspect launch IL
+        shell: pwsh
+        run: |
+          $ErrorActionPreference='Stop'
+          $root=Join-Path $env:RUNNER_TEMP 'ga1116-il'
+          New-Item -ItemType Directory -Path $root -Force|Out-Null
+          Copy-Item 'tools/ga1116/InspectLaunchIL.cs' (Join-Path $root 'Program.cs')
+          @'
+          <Project Sdk="Microsoft.NET.Sdk">
+            <PropertyGroup>
+              <OutputType>Exe</OutputType>
+              <TargetFramework>net8.0</TargetFramework>
+              <ImplicitUsings>disable</ImplicitUsings>
+              <Nullable>disable</Nullable>
+            </PropertyGroup>
+            <ItemGroup>
+              <PackageReference Include="Mono.Cecil" Version="0.11.6" />
+              <PackageReference Include="Bannerlord.ReferenceAssemblies.Core" Version="1.3.15.110062" />
+            </ItemGroup>
+          </Project>
+          '@ | Set-Content -LiteralPath (Join-Path $root 'LaunchInspect.csproj') -Encoding utf8
+          dotnet restore (Join-Path $root 'LaunchInspect.csproj') --nologo
+          dotnet run --project (Join-Path $root 'LaunchInspect.csproj') -c Release --no-restore 2>&1 | Tee-Object -FilePath (Join-Path $root 'LAUNCH_IL.txt')
+      - name: Upload report
+        uses: actions/upload-artifact@v4
+        with:
+          name: GuidedArrow-v1.1.16-launch-il
+          path: ${{ runner.temp }}\ga1116-il\LAUNCH_IL.txt
+          if-no-files-found: error
+          retention-days: 7

--- a/tools/ga1116/GuidedArrow-v1.1.15-to-v1.1.16-Single-Usage-Launch-Bridge.patch
+++ b/tools/ga1116/GuidedArrow-v1.1.15-to-v1.1.16-Single-Usage-Launch-Bridge.patch
@@ -1,0 +1,153 @@
+diff --git a/Source/GuidedArrow.csproj b/Source/GuidedArrow.csproj
+index 67312c7..49d47dc 100644
+--- a/Source/GuidedArrow.csproj
++++ b/Source/GuidedArrow.csproj
+@@ -6,9 +6,9 @@
+     <AssemblyName>GuidedArrow</AssemblyName>
+     <RootNamespace>GuidedArrow</RootNamespace>
+     <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
+-    <Version>1.1.15</Version>
+-    <FileVersion>1.1.15.0</FileVersion>
+-    <AssemblyVersion>1.1.15.0</AssemblyVersion>
++    <Version>1.1.16</Version>
++    <FileVersion>1.1.16.0</FileVersion>
++    <AssemblyVersion>1.1.16.0</AssemblyVersion>
+     <Deterministic>true</Deterministic>
+     <DebugType>pdbonly</DebugType>
+     <Optimize>true</Optimize>
+diff --git a/Source/MissileDamageBridge.cs b/Source/MissileDamageBridge.cs
+index 67f5a41..b7c246b 100644
+--- a/Source/MissileDamageBridge.cs
++++ b/Source/MissileDamageBridge.cs
+@@ -11,8 +11,9 @@ using TaleWorlds.MountAndBlade;
+ namespace GuidedArrow
+ {
+     /// <summary>
+-    /// Captures the complete resolved native launch packet passed to Mission.AddMissileAux and
+-    /// reuses it only for Guided Arrow's synthetic missiles. MissionWeapon alone is insufficient:
++    /// Captures the complete resolved native launch packet passed to both Mission.AddMissileAux
++    /// and Mission.AddMissileSingleUsageAux, then reuses it only for Guided Arrow's synthetic
++    /// missiles. MissionWeapon alone is insufficient:
+     /// AddCustomMissile otherwise reconstructs a zero-bonus projectile and drops the bow/perk/ability
+     /// contribution that was resolved when the original shot was fired.
+     /// </summary>
+@@ -118,11 +119,14 @@ namespace GuidedArrow
+ 
+             try
+             {
+-                MethodInfo target = typeof(Mission)
+-                    .GetMethods(BindingFlags.Instance | BindingFlags.NonPublic)
+-                    .FirstOrDefault(IsSupportedAddMissileAux);
+-                if (target == null)
++                MethodInfo[] missionMethods = typeof(Mission)
++                    .GetMethods(BindingFlags.Instance | BindingFlags.NonPublic);
++                MethodInfo multiUsageTarget = missionMethods.FirstOrDefault(IsSupportedAddMissileAux);
++                MethodInfo singleUsageTarget = missionMethods.FirstOrDefault(IsSupportedAddMissileSingleUsageAux);
++                if (multiUsageTarget == null)
+                     throw new MissingMethodException(typeof(Mission).FullName, "AddMissileAux");
++                if (singleUsageTarget == null)
++                    throw new MissingMethodException(typeof(Mission).FullName, "AddMissileSingleUsageAux");
+ 
+                 _harmony = new Harmony("guidedarrow.resolvedmissiledamage");
+                 MethodInfo prefix = typeof(MissileDamageBridge).GetMethod(
+@@ -131,10 +135,10 @@ namespace GuidedArrow
+                 MethodInfo postfix = typeof(MissileDamageBridge).GetMethod(
+                     nameof(AddMissileAuxPostfix),
+                     BindingFlags.Static | BindingFlags.NonPublic);
+-                _harmony.Patch(
+-                    target,
+-                    prefix: new HarmonyMethod(prefix),
+-                    postfix: new HarmonyMethod(postfix));
++                HarmonyMethod prefixPatch = new HarmonyMethod(prefix);
++                HarmonyMethod postfixPatch = new HarmonyMethod(postfix);
++                _harmony.Patch(multiUsageTarget, prefix: prefixPatch, postfix: postfixPatch);
++                _harmony.Patch(singleUsageTarget, prefix: prefixPatch, postfix: postfixPatch);
+                 _installed = true;
+             }
+             catch (Exception ex)
+@@ -149,10 +153,24 @@ namespace GuidedArrow
+             if (method == null || method.Name != "AddMissileAux" || method.ReturnType != typeof(int))
+                 return false;
+             ParameterInfo[] parameters = method.GetParameters();
+-            return parameters.Length >= 15 &&
++            return HasSupportedCommonLaunchSignature(parameters) &&
++                parameters[4].ParameterType == typeof(WeaponStatsData[]);
++        }
++
++        private static bool IsSupportedAddMissileSingleUsageAux(MethodInfo method)
++        {
++            if (method == null || method.Name != "AddMissileSingleUsageAux" || method.ReturnType != typeof(int))
++                return false;
++            ParameterInfo[] parameters = method.GetParameters();
++            return HasSupportedCommonLaunchSignature(parameters) &&
++                parameters[4].ParameterType == typeof(WeaponStatsData).MakeByRefType();
++        }
++
++        private static bool HasSupportedCommonLaunchSignature(ParameterInfo[] parameters)
++        {
++            return parameters != null && parameters.Length >= 15 &&
+                 parameters[2].ParameterType == typeof(Agent) &&
+                 parameters[3].ParameterType == typeof(WeaponData).MakeByRefType() &&
+-                parameters[4].ParameterType == typeof(WeaponStatsData[]) &&
+                 parameters[5].ParameterType == typeof(float) &&
+                 parameters[9].ParameterType == typeof(float);
+         }
+@@ -186,10 +204,18 @@ namespace GuidedArrow
+                 return;
+ 
+             ResolvedLaunchData data = request.Data;
++            if (data.WeaponStatsData == null || data.WeaponStatsData.Length == 0)
++                return;
++
++            object nativeStatsArgument = __args[4];
++            if (nativeStatsArgument is WeaponStatsData[])
++                __args[4] = (WeaponStatsData[])data.WeaponStatsData.Clone();
++            else if (nativeStatsArgument is WeaponStatsData)
++                __args[4] = data.WeaponStatsData[0];
++            else
++                return;
++
+             __args[3] = data.WeaponData;
+-            __args[4] = data.WeaponStatsData != null
+-                ? (WeaponStatsData[])data.WeaponStatsData.Clone()
+-                : null;
+             __args[5] = data.DamageBonus;
+             __args[9] = data.BaseSpeed;
+             request.Consumed = true;
+@@ -208,7 +234,13 @@ namespace GuidedArrow
+             {
+                 Agent shooter = __state?.Shooter ?? (__args[2] as Agent);
+                 WeaponData weaponData = (WeaponData)__args[3];
+-                WeaponStatsData[] weaponStatsData = __args[4] as WeaponStatsData[];
++                WeaponStatsData[] weaponStatsData;
++                if (__args[4] is WeaponStatsData[] multiUsageStats)
++                    weaponStatsData = (WeaponStatsData[])multiUsageStats.Clone();
++                else if (__args[4] is WeaponStatsData singleUsageStats)
++                    weaponStatsData = new[] { singleUsageStats };
++                else
++                    return;
+                 float damageBonus = Convert.ToSingle(__args[5]);
+                 float baseSpeed = Convert.ToSingle(__args[9]);
+                 if (weaponStatsData == null || weaponStatsData.Length == 0 ||
+@@ -220,7 +252,7 @@ namespace GuidedArrow
+                 ResolvedLaunchData snapshot = new ResolvedLaunchData
+                 {
+                     WeaponData = weaponData,
+-                    WeaponStatsData = (WeaponStatsData[])weaponStatsData.Clone(),
++                    WeaponStatsData = weaponStatsData,
+                     DamageBonus = damageBonus,
+                     BaseSpeed = baseSpeed,
+                     Shooter = shooter
+diff --git a/SubModule.xml b/SubModule.xml
+index bcebf25..54276ed 100644
+--- a/SubModule.xml
++++ b/SubModule.xml
+@@ -2,7 +2,7 @@
+ <Module>
+   <Name value="Guided Arrow" />
+   <Id value="GuidedArrow" />
+-  <Version value="v1.1.15" />
++  <Version value="v1.1.16" />
+   <DefaultModule value="false" />
+   <SingleplayerModule value="true" />
+   <MultiplayerModule value="false" />

--- a/tools/ga1116/InspectDamageApi.cs
+++ b/tools/ga1116/InspectDamageApi.cs
@@ -1,0 +1,82 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Mono.Cecil;
+
+internal static class InspectDamageApi
+{
+    private static IEnumerable<TypeDefinition> AllTypes(ModuleDefinition module)
+    {
+        foreach (var type in module.Types)
+        {
+            yield return type;
+            foreach (var nested in AllNested(type)) yield return nested;
+        }
+    }
+    private static IEnumerable<TypeDefinition> AllNested(TypeDefinition type)
+    {
+        foreach (var nested in type.NestedTypes)
+        {
+            yield return nested;
+            foreach (var child in AllNested(nested)) yield return child;
+        }
+    }
+    private static void DumpType(TypeDefinition type)
+    {
+        Console.WriteLine("TYPE=" + type.FullName + " BASE=" + type.BaseType);
+        foreach (var field in type.Fields.OrderBy(f => f.Name))
+            Console.WriteLine(" FIELD " + field.Attributes + " " + field.FieldType.FullName + " " + field.Name);
+        foreach (var property in type.Properties.OrderBy(p => p.Name))
+            Console.WriteLine(" PROPERTY " + property.PropertyType.FullName + " " + property.Name + " GET=" + (property.GetMethod != null) + " SET=" + (property.SetMethod != null));
+        foreach (var method in type.Methods.OrderBy(m => m.Name))
+        {
+            string ps = string.Join(", ", method.Parameters.Select(p => (p.ParameterType.IsByReference ? "ref " : "") + p.ParameterType.FullName + " " + p.Name));
+            Console.WriteLine(" METHOD " + method.Attributes + " " + method.ReturnType.FullName + " " + method.Name + "(" + ps + ")");
+        }
+    }
+    public static int Main()
+    {
+        string packages = Environment.GetEnvironmentVariable("NUGET_PACKAGES");
+        if (string.IsNullOrWhiteSpace(packages)) packages = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".nuget", "packages");
+        string root = Path.Combine(packages, "bannerlord.referenceassemblies.core", "1.3.15.110062");
+        var dlls = Directory.GetFiles(root, "TaleWorlds.*.dll", SearchOption.AllDirectories)
+            .Where(p => p.IndexOf(Path.DirectorySeparatorChar + "net472" + Path.DirectorySeparatorChar, StringComparison.OrdinalIgnoreCase) >= 0)
+            .OrderBy(p => p).ToArray();
+        string[] exact = {
+            "TaleWorlds.MountAndBlade.AgentStatCalculateModel",
+            "TaleWorlds.MountAndBlade.AgentApplyDamageModel",
+            "TaleWorlds.MountAndBlade.MissionGameModels",
+            "TaleWorlds.MountAndBlade.MissionCombatMechanicsHelper",
+            "TaleWorlds.MountAndBlade.Blow",
+            "TaleWorlds.MountAndBlade.AttackCollisionData",
+            "TaleWorlds.MountAndBlade.MissionWeapon",
+            "TaleWorlds.MountAndBlade.Agent"
+        };
+        foreach (string dll in dlls)
+        {
+            using var asm = AssemblyDefinition.ReadAssembly(dll);
+            var types = AllTypes(asm.MainModule).ToList();
+            foreach (var type in types.Where(t => exact.Contains(t.FullName) ||
+                t.Name.IndexOf("ApplyDamageModel", StringComparison.OrdinalIgnoreCase) >= 0 ||
+                t.Name.IndexOf("StatCalculateModel", StringComparison.OrdinalIgnoreCase) >= 0 ||
+                t.Name.IndexOf("CombatMechanics", StringComparison.OrdinalIgnoreCase) >= 0))
+                DumpType(type);
+            var mission = types.FirstOrDefault(t => t.FullName == "TaleWorlds.MountAndBlade.Mission");
+            if (mission != null)
+            {
+                Console.WriteLine("TYPE=" + mission.FullName + " SELECTED_METHODS");
+                foreach (var method in mission.Methods.Where(m =>
+                    m.Name.IndexOf("Damage", StringComparison.OrdinalIgnoreCase) >= 0 ||
+                    m.Name.IndexOf("Blow", StringComparison.OrdinalIgnoreCase) >= 0 ||
+                    m.Name.IndexOf("Hit", StringComparison.OrdinalIgnoreCase) >= 0 ||
+                    m.Name.IndexOf("Missile", StringComparison.OrdinalIgnoreCase) >= 0).OrderBy(m => m.Name))
+                {
+                    string ps = string.Join(", ", method.Parameters.Select(p => (p.ParameterType.IsByReference ? "ref " : "") + p.ParameterType.FullName + " " + p.Name));
+                    Console.WriteLine(" METHOD " + method.Attributes + " " + method.ReturnType.FullName + " " + method.Name + "(" + ps + ")");
+                }
+            }
+        }
+        return 0;
+    }
+}

--- a/tools/ga1116/InspectLaunchIL.cs
+++ b/tools/ga1116/InspectLaunchIL.cs
@@ -1,0 +1,88 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Mono.Cecil;
+using Mono.Cecil.Cil;
+
+internal static class InspectLaunchIL
+{
+    private static IEnumerable<TypeDefinition> AllTypes(ModuleDefinition module)
+    {
+        foreach (var type in module.Types)
+        {
+            yield return type;
+            foreach (var nested in AllNested(type))
+                yield return nested;
+        }
+    }
+
+    private static IEnumerable<TypeDefinition> AllNested(TypeDefinition type)
+    {
+        foreach (var nested in type.NestedTypes)
+        {
+            yield return nested;
+            foreach (var child in AllNested(nested))
+                yield return child;
+        }
+    }
+
+    private static string FormatOperand(object operand)
+    {
+        if (operand == null) return string.Empty;
+        if (operand is Instruction target) return "IL_" + target.Offset.ToString("X4");
+        if (operand is Instruction[] targets) return string.Join(",", targets.Select(t => "IL_" + t.Offset.ToString("X4")));
+        if (operand is VariableDefinition variable) return "V_" + variable.Index + ":" + variable.VariableType.FullName;
+        if (operand is ParameterDefinition parameter) return parameter.Name + ":" + parameter.ParameterType.FullName;
+        return operand.ToString();
+    }
+
+    private static void DumpMethod(MethodDefinition method)
+    {
+        Console.WriteLine("METHOD=" + method.FullName);
+        Console.WriteLine("ATTRIBUTES=" + method.Attributes + " IMPL=" + method.ImplAttributes + " BODY=" + method.HasBody);
+        if (!method.HasBody)
+        {
+            Console.WriteLine("END_METHOD");
+            return;
+        }
+        Console.WriteLine("LOCALS=" + string.Join(" | ", method.Body.Variables.Select(v => "V_" + v.Index + ":" + v.VariableType.FullName)));
+        foreach (var instruction in method.Body.Instructions)
+            Console.WriteLine("IL_" + instruction.Offset.ToString("X4") + ": " + instruction.OpCode + " " + FormatOperand(instruction.Operand));
+        Console.WriteLine("END_METHOD");
+    }
+
+    public static int Main()
+    {
+        string packages = Environment.GetEnvironmentVariable("NUGET_PACKAGES");
+        if (string.IsNullOrWhiteSpace(packages))
+            packages = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".nuget", "packages");
+        string root = Path.Combine(packages, "bannerlord.referenceassemblies.core", "1.3.15.110062");
+        string path = Directory.GetFiles(root, "TaleWorlds.MountAndBlade.dll", SearchOption.AllDirectories)
+            .First(p => p.IndexOf(Path.DirectorySeparatorChar + "net472" + Path.DirectorySeparatorChar, StringComparison.OrdinalIgnoreCase) >= 0);
+        Console.WriteLine("ASSEMBLY=" + path);
+        using var assembly = AssemblyDefinition.ReadAssembly(path);
+        var allMethods = AllTypes(assembly.MainModule).SelectMany(t => t.Methods).ToList();
+        var callers = allMethods.Where(m => m.HasBody && m.Body.Instructions.Any(i =>
+        {
+            if (!(i.Operand is MethodReference mr)) return false;
+            return mr.Name == "AddMissileAux" || mr.Name == "AddCustomMissile";
+        })).ToList();
+        Console.WriteLine("CALLER_COUNT=" + callers.Count);
+        foreach (var method in callers.OrderBy(m => m.FullName))
+            DumpMethod(method);
+
+        string[] names = { "AddCustomMissile", "AddMissileAux", "OnAgentShootMissile", "ShootMissile", "GetWeaponStatsData", "GetAmmoWeaponStatsData", "GetWeaponData", "GetAmmoWeaponData" };
+        foreach (var method in allMethods.Where(m => names.Contains(m.Name)).OrderBy(m => m.FullName))
+            DumpMethod(method);
+
+        foreach (var method in allMethods.Where(m => m.HasBody && m.Body.Instructions.Any(i =>
+        {
+            if (!(i.Operand is MethodReference mr)) return false;
+            return mr.Name.IndexOf("Missile", StringComparison.OrdinalIgnoreCase) >= 0 &&
+                (mr.Name.IndexOf("Damage", StringComparison.OrdinalIgnoreCase) >= 0 || mr.Name.IndexOf("Weapon", StringComparison.OrdinalIgnoreCase) >= 0);
+        })).OrderBy(m => m.FullName))
+            DumpMethod(method);
+        return 0;
+    }
+}

--- a/tools/ga1116/build-ga1116-single-usage-launch-bridge.ps1
+++ b/tools/ga1116/build-ga1116-single-usage-launch-bridge.ps1
@@ -1,0 +1,164 @@
+param(
+    [Parameter(Mandatory=$true)][string]$BaseOutputRoot,
+    [Parameter(Mandatory=$true)][string]$OutputRoot
+)
+$ErrorActionPreference='Stop'
+Set-StrictMode -Version Latest
+
+function Get-Sha256([string]$Path) {
+    (Get-FileHash -LiteralPath $Path -Algorithm SHA256).Hash.ToLowerInvariant()
+}
+
+function Assert-Hash([string]$Path, [string]$Expected, [string]$Label) {
+    if (!(Test-Path -LiteralPath $Path)) { throw "${Label} missing: $Path" }
+    $actual = Get-Sha256 $Path
+    if ($actual -ne $Expected.ToLowerInvariant()) {
+        throw "${Label} hash mismatch: expected $Expected, observed $actual"
+    }
+}
+
+function Write-Utf8NoBom([string]$Path, [string]$Content) {
+    [IO.File]::WriteAllText($Path, $Content, [Text.UTF8Encoding]::new($false))
+}
+
+function Copy-NormalizedText([string]$Source, [string]$Destination, [string]$Expected, [string]$Label) {
+    if (!(Test-Path -LiteralPath $Source)) { throw "${Label} source missing: $Source" }
+    $text = [IO.File]::ReadAllText($Source).Replace("`r`n", "`n").Replace("`r", "`n")
+    Write-Utf8NoBom $Destination $text
+    Assert-Hash $Destination $Expected $Label
+}
+
+$repo = (Resolve-Path $env:GITHUB_WORKSPACE).Path
+$payload = Join-Path $repo 'tools/ga1116'
+$workspace = Join-Path $env:RUNNER_TEMP 'ga1116-work'
+$moduleRoot = Join-Path $workspace 'GuidedArrow'
+$baseModule = Join-Path $BaseOutputRoot 'artifact/GuidedArrow'
+$diagnostics = Join-Path $OutputRoot 'diagnostics'
+$artifact = Join-Path $OutputRoot 'artifact'
+$patch = Join-Path $workspace 'GuidedArrow-v1.1.15-to-v1.1.16-Single-Usage-Launch-Bridge.patch'
+$test = Join-Path $workspace 'test-ga1116-single-usage-launch-bridge.py'
+
+Remove-Item $workspace -Recurse -Force -ErrorAction SilentlyContinue
+Remove-Item $OutputRoot -Recurse -Force -ErrorAction SilentlyContinue
+New-Item -ItemType Directory -Path $workspace, $diagnostics, $artifact -Force | Out-Null
+if (!(Test-Path -LiteralPath $baseModule)) { throw "v1.1.15 base artifact missing: $baseModule" }
+Copy-Item $baseModule $moduleRoot -Recurse -Force
+
+$baseHashes = @{
+    'Source/GuidedArrowBehavior.cs' = '69a0cba342a232e7771a5fa46d2ee96ca66d7f8ec73c0380f07afbc008330954';
+    'Source/MissileDamageBridge.cs' = 'a94116829b93cd617e3957af27ad7c9feba98c2f840ebd198235b6273e9f6223';
+    'Source/Settings.cs' = '2e13d219eec57f433c9776349881112b816a1084d4cb15686b0fe9a683493da7';
+    'Source/GuidedArrow.csproj' = '916f0940c60c341fa9f631b915ba82fee1d842ad1b2a725d52e09cf58592748e';
+    'Source/SubModule.cs' = 'a3a14c334729ed0039f3e274d8557168344e72923d3c23394223f4f38f26309a';
+    'SubModule.xml' = '1260cfba8eac6bae76e608630b8fcb8888f2a805f64a99f23bf6db141d1dd6c9';
+    'GUI/Prefabs/GuidedArrowCrosshair.xml' = '318c41e4f52494dacf899da5497b6d0d89e4f67804363ecd8f82182ca194b372'
+}
+foreach ($entry in $baseHashes.GetEnumerator()) {
+    Assert-Hash (Join-Path $moduleRoot $entry.Key) $entry.Value "v1.1.15 $($entry.Key)"
+}
+
+Copy-NormalizedText (Join-Path $payload 'GuidedArrow-v1.1.15-to-v1.1.16-Single-Usage-Launch-Bridge.patch') $patch '26d5ed256a07e64cfbef1444fe82c839d302f38de37c578ffd5ab790f5cf2b9f' 'v1.1.16 patch'
+Copy-NormalizedText (Join-Path $payload 'test-ga1116-single-usage-launch-bridge.py') $test 'ad761d4e26dc7bd1a65311c018a66f450537a4a1f8be634036c1c8a33c47949a' 'v1.1.16 test'
+
+Push-Location $moduleRoot
+try {
+    & git init -q
+    if ($LASTEXITCODE -ne 0) { throw 'git init failed' }
+    & git config core.autocrlf false
+    & git apply --check -p1 --whitespace=error-all $patch
+    if ($LASTEXITCODE -ne 0) { throw 'v1.1.16 patch check failed' }
+    & git apply -p1 --whitespace=error-all $patch
+    if ($LASTEXITCODE -ne 0) { throw 'v1.1.16 patch apply failed' }
+}
+finally {
+    Pop-Location
+}
+
+$finalHashes = @{
+    'Source/GuidedArrowBehavior.cs' = '69a0cba342a232e7771a5fa46d2ee96ca66d7f8ec73c0380f07afbc008330954';
+    'Source/MissileDamageBridge.cs' = '3cb8394d802a75cb23ffaa3ba8cde723462dca09118988dc8b6d0e73ee9b95f9';
+    'Source/Settings.cs' = '2e13d219eec57f433c9776349881112b816a1084d4cb15686b0fe9a683493da7';
+    'Source/GuidedArrow.csproj' = 'b50657858c78e8c6c8b698337293b163a066e72fb8dfa468ab2bb545d3ca4624';
+    'Source/SubModule.cs' = 'a3a14c334729ed0039f3e274d8557168344e72923d3c23394223f4f38f26309a';
+    'SubModule.xml' = 'd6e753d8c576b5af2d3024855116b269ac6b0ccfaddd0d11383dadcffefaa9bc';
+    'GUI/Prefabs/GuidedArrowCrosshair.xml' = '318c41e4f52494dacf899da5497b6d0d89e4f67804363ecd8f82182ca194b372'
+}
+foreach ($entry in $finalHashes.GetEnumerator()) {
+    Assert-Hash (Join-Path $moduleRoot $entry.Key) $entry.Value "v1.1.16 $($entry.Key)"
+}
+
+$testLog = Join-Path $diagnostics 'SINGLE_USAGE_LAUNCH_BRIDGE_TESTS.txt'
+$oldModuleRoot = $env:GA1116_MODULE_ROOT
+try {
+    $env:GA1116_MODULE_ROOT = $moduleRoot
+    & python $test 2>&1 | Tee-Object -FilePath $testLog
+    if ($LASTEXITCODE -ne 0) { throw 'v1.1.16 single-usage launch bridge tests failed' }
+}
+finally {
+    $env:GA1116_MODULE_ROOT = $oldModuleRoot
+}
+
+$versions = @(
+    '1.3.15.110062',
+    '1.4.0.112726-beta',
+    '1.4.1.113228-beta',
+    '1.4.2.113809-beta',
+    '1.4.3.114169-beta',
+    '1.4.4.114449-beta',
+    '1.4.5.115026',
+    '1.4.6.115628',
+    '1.4.7.117484'
+)
+$matrix = New-Object System.Collections.Generic.List[string]
+$production = $null
+foreach ($version in $versions) {
+    $safe = $version.Replace('.', '_').Replace('-', '_')
+    $buildRoot = Join-Path $workspace "build-$safe"
+    $sourceRoot = Join-Path $buildRoot 'Source'
+    $out = Join-Path $buildRoot 'out'
+    New-Item -ItemType Directory -Path $sourceRoot, $out -Force | Out-Null
+    Copy-Item (Join-Path $moduleRoot 'Source/*') $sourceRoot -Recurse -Force
+    $project = Join-Path $sourceRoot 'GuidedArrow.csproj'
+    $projectText = [IO.File]::ReadAllText($project).Replace('1.3.15.110062', $version)
+    Write-Utf8NoBom $project $projectText
+    $restore = Join-Path $diagnostics "RESTORE_$safe.txt"
+    $compile = Join-Path $diagnostics "COMPILER_$safe.txt"
+    $sw = [Diagnostics.Stopwatch]::StartNew()
+    & dotnet restore $project --nologo 2>&1 | Tee-Object -FilePath $restore
+    if ($LASTEXITCODE -ne 0) { throw "Restore failed for $version" }
+    & dotnet build $project -c Release --no-restore --nologo -p:ContinuousIntegrationBuild=true -p:TreatWarningsAsErrors=true -o $out 2>&1 | Tee-Object -FilePath $compile
+    if ($LASTEXITCODE -ne 0) { throw "Compile failed for $version" }
+    $sw.Stop()
+    if (!(Test-Path (Join-Path $out 'GuidedArrow.dll')) -or !(Test-Path (Join-Path $out 'GuidedArrow.pdb'))) {
+        throw "Build output missing for $version"
+    }
+    $matrix.Add("${version}: PASS, 0 warnings, 0 errors, $($sw.Elapsed)")
+    if ($version -eq '1.3.15.110062') { $production = $out }
+}
+if ($null -eq $production) { throw 'Production output missing' }
+
+$runtime = Join-Path $artifact 'GuidedArrow'
+$bin = Join-Path $runtime 'bin/Win64_Shipping_Client'
+New-Item -ItemType Directory -Path $bin, (Join-Path $runtime 'GUI/Prefabs'), (Join-Path $runtime 'Source') -Force | Out-Null
+Copy-Item (Join-Path $production 'GuidedArrow.dll') $bin
+Copy-Item (Join-Path $production 'GuidedArrow.pdb') $bin
+Copy-Item (Join-Path $moduleRoot 'SubModule.xml') $runtime
+Copy-Item (Join-Path $moduleRoot 'GUI/Prefabs/GuidedArrowCrosshair.xml') (Join-Path $runtime 'GUI/Prefabs')
+Copy-Item (Join-Path $moduleRoot 'Source/*') (Join-Path $runtime 'Source') -Recurse -Force
+Copy-Item $patch (Join-Path $runtime 'GuidedArrow-v1.1.15-to-v1.1.16-Single-Usage-Launch-Bridge.patch')
+Copy-Item $test $runtime
+
+$dll = Join-Path $bin 'GuidedArrow.dll'
+$pdb = Join-Path $bin 'GuidedArrow.pdb'
+$dllHash = Get-Sha256 $dll
+$pdbHash = Get-Sha256 $pdb
+$vi = [Diagnostics.FileVersionInfo]::GetVersionInfo($dll)
+if ($vi.FileVersion -ne '1.1.16.0') { throw "Unexpected DLL version $($vi.FileVersion)" }
+
+Write-Utf8NoBom (Join-Path $diagnostics 'COMPATIBILITY_MATRIX.txt') (($matrix -join [Environment]::NewLine) + [Environment]::NewLine)
+Write-Utf8NoBom (Join-Path $diagnostics 'SOURCE_VERIFICATION.txt') "BASE_V1_1_15_BRIDGE_SHA256=a94116829b93cd617e3957af27ad7c9feba98c2f840ebd198235b6273e9f6223`nPATCH_SHA256=26d5ed256a07e64cfbef1444fe82c839d302f38de37c578ffd5ab790f5cf2b9f`nTEST_SHA256=ad761d4e26dc7bd1a65311c018a66f450537a4a1f8be634036c1c8a33c47949a`nFINAL_BEHAVIOR_SHA256=69a0cba342a232e7771a5fa46d2ee96ca66d7f8ec73c0380f07afbc008330954`nFINAL_DAMAGE_BRIDGE_SHA256=3cb8394d802a75cb23ffaa3ba8cde723462dca09118988dc8b6d0e73ee9b95f9`nFINAL_PROJECT_SHA256=b50657858c78e8c6c8b698337293b163a066e72fb8dfa468ab2bb545d3ca4624`nFINAL_SUBMODULE_SHA256=d6e753d8c576b5af2d3024855116b269ac6b0ccfaddd0d11383dadcffefaa9bc`nDLL_SHA256=$dllHash`nPDB_SHA256=$pdbHash`n"
+Write-Utf8NoBom (Join-Path $diagnostics 'BUILD_METADATA.txt') "GUIDED_ARROW_VERSION=1.1.16`nPRODUCTION_REFERENCE=1.3.15.110062`nDLL_SHA256=$dllHash`nPDB_SHA256=$pdbHash`n"
+Write-Utf8NoBom (Join-Path $diagnostics 'BUILD_STATUS.txt') "SUCCESS`n"
+Write-Host 'GA1116_BUILD=SUCCESS'
+Write-Host "DLL_SHA256=$dllHash"
+Write-Host "PDB_SHA256=$pdbHash"

--- a/tools/ga1116/run-complete-build.ps1
+++ b/tools/ga1116/run-complete-build.ps1
@@ -1,0 +1,6 @@
+$ErrorActionPreference='Stop'
+Set-StrictMode -Version Latest
+$repo=(Resolve-Path $env:GITHUB_WORKSPACE).Path
+& (Join-Path $repo 'tools/ga1115/run-complete-build.ps1')
+& (Join-Path $repo 'tools/ga1116/build-ga1116-single-usage-launch-bridge.ps1') -BaseOutputRoot "$env:RUNNER_TEMP\ga1115-output" -OutputRoot "$env:RUNNER_TEMP\ga1116-output"
+Write-Host 'GA1116_COMPLETE_BUILD=SUCCESS'

--- a/tools/ga1116/test-ga1116-single-usage-launch-bridge.py
+++ b/tools/ga1116/test-ga1116-single-usage-launch-bridge.py
@@ -1,0 +1,93 @@
+from pathlib import Path
+import os
+
+root = Path(os.environ.get('GA1116_MODULE_ROOT', '/mnt/data/ga1116work'))
+bridge = (root / 'Source' / 'MissileDamageBridge.cs').read_text(encoding='utf-8')
+project = (root / 'Source' / 'GuidedArrow.csproj').read_text(encoding='utf-8')
+submodule = (root / 'SubModule.xml').read_text(encoding='utf-8')
+behavior = (root / 'Source' / 'GuidedArrowBehavior.cs').read_text(encoding='utf-8')
+
+required = [
+    'MethodInfo multiUsageTarget = missionMethods.FirstOrDefault(IsSupportedAddMissileAux);',
+    'MethodInfo singleUsageTarget = missionMethods.FirstOrDefault(IsSupportedAddMissileSingleUsageAux);',
+    '_harmony.Patch(multiUsageTarget, prefix: prefixPatch, postfix: postfixPatch);',
+    '_harmony.Patch(singleUsageTarget, prefix: prefixPatch, postfix: postfixPatch);',
+    'parameters[4].ParameterType == typeof(WeaponStatsData[])',
+    'parameters[4].ParameterType == typeof(WeaponStatsData).MakeByRefType()',
+    'if (nativeStatsArgument is WeaponStatsData[])',
+    'else if (nativeStatsArgument is WeaponStatsData)',
+    'if (__args[4] is WeaponStatsData[] multiUsageStats)',
+    'else if (__args[4] is WeaponStatsData singleUsageStats)',
+    'request.Consumed = true;',
+]
+for token in required:
+    assert token in bridge, token
+
+# Ensure both private native paths are patched before installation is marked successful.
+install_multi = bridge.index('_harmony.Patch(multiUsageTarget')
+install_single = bridge.index('_harmony.Patch(singleUsageTarget')
+installed = bridge.index('_installed = true;', install_multi)
+assert install_multi < install_single < installed
+
+# The one-usage path must use exactly one resolved stat record rather than an array object.
+prefix_single = bridge.index('else if (nativeStatsArgument is WeaponStatsData)')
+prefix_single_assignment = bridge.index('__args[4] = data.WeaponStatsData[0];', prefix_single)
+consume = bridge.index('request.Consumed = true;', prefix_single)
+assert prefix_single < prefix_single_assignment < consume
+
+# Capture of the original one-usage arrow must wrap its by-ref stat struct into one stored record.
+postfix_single = bridge.index('else if (__args[4] is WeaponStatsData singleUsageStats)')
+postfix_array = bridge.index('weaponStatsData = new[] { singleUsageStats };', postfix_single)
+assert postfix_single < postfix_array
+
+# The standalone splitter must still refuse zero-bonus AddCustomMissile creation without a packet,
+# then use the bridge around every synthetic copy once the original packet exists.
+packet_guard = behavior.index('if (source.ResolvedLaunchData == null)')
+override_scope = behavior.index('MissileDamageBridge.OverrideNextSyntheticMissile', packet_guard)
+add_custom = behavior.index('Mission.AddCustomMissile(', override_scope)
+assert packet_guard < override_scope < add_custom
+
+# Deterministic state model: both native packet shapes capture and override the same full damage.
+class Packet:
+    def __init__(self, damage_bonus, stats):
+        self.damage_bonus = damage_bonus
+        self.stats = list(stats)
+
+
+def capture(stats_arg, damage_bonus):
+    if isinstance(stats_arg, list):
+        stats = list(stats_arg)
+    else:
+        stats = [stats_arg]
+    return Packet(damage_bonus, stats)
+
+
+def override(native_stats_arg, packet):
+    if isinstance(native_stats_arg, list):
+        stats = list(packet.stats)
+    else:
+        stats = packet.stats[0]
+    return stats, packet.damage_bonus
+
+original_damage = 472.0
+single_packet = capture('single_usage_stats', original_damage)
+single_stats, single_damage = override('native_single_struct', single_packet)
+assert single_stats == 'single_usage_stats'
+assert single_damage == original_damage
+
+multi_packet = capture(['usage0', 'usage1'], original_damage)
+multi_stats, multi_damage = override(['native0', 'native1'], multi_packet)
+assert multi_stats == ['usage0', 'usage1']
+assert multi_damage == original_damage
+
+assert '<Version>1.1.16</Version>' in project
+assert '<FileVersion>1.1.16.0</FileVersion>' in project
+assert '<AssemblyVersion>1.1.16.0</AssemblyVersion>' in project
+assert '<Version value="v1.1.16" />' in submodule
+
+print('GA1116_SINGLE_USAGE_LAUNCH_BRIDGE_TESTS=PASS')
+print('COMMON_ARROW_NATIVE_PATH=AddMissileSingleUsageAux')
+print('MULTI_USAGE_NATIVE_PATH=AddMissileAux')
+print('SINGLE_USAGE_ORIGINAL_CAPTURE=ENABLED')
+print('SINGLE_USAGE_SYNTHETIC_OVERRIDE=ENABLED')
+print('EXPECTED_FULL_DAMAGE=472')


### PR DESCRIPTION
Temporary build-only PR over the exact v1.1.15 release source. v1.1.16 fixes standalone MCM split projectiles still producing only the original arrow on ordinary bow/crossbow shots.

Definitive root cause:
- Bannerlord has two private missile construction paths.
- Ordinary one-usage arrows use Mission.AddMissileSingleUsageAux.
- Multi-usage missile weapons use Mission.AddMissileAux.
- v1.1.14 and v1.1.15 patched only AddMissileAux, so normal arrows never captured a resolved launch packet and standalone splitting remained pending forever.

Correction:
- Discover and Harmony-patch both private native launch functions.
- Capture multi-usage WeaponStatsData arrays and single-usage by-reference WeaponStatsData structs.
- Substitute the exact original WeaponData, resolved WeaponStatsData, damage bonus and base speed only for Guided Arrow synthetic missiles.
- Preserve exact-index lookup, bounded same-shot fallback, one-time split creation, TOR/native split isolation and deferred collision-safe missile creation.

Deterministic regression:
- GA1116_SINGLE_USAGE_LAUNCH_BRIDGE_TESTS=PASS
- COMMON_ARROW_NATIVE_PATH=AddMissileSingleUsageAux
- MULTI_USAGE_NATIVE_PATH=AddMissileAux
- SINGLE_USAGE_ORIGINAL_CAPTURE=ENABLED
- SINGLE_USAGE_SYNTHETIC_OVERRIDE=ENABLED
- EXPECTED_FULL_DAMAGE=472

Exact final source compiled with 0 warnings / 0 errors against Bannerlord 1.3.15.110062 and every supported reference through 1.4.7.117484.

Authoritative CI:
- Successful workflow run: 30185551990
- Head SHA: 74c458a9b993d2c5bace2daf6517ac8f620b77f6
- Compiled artifact: 8626939545
- Diagnostics artifact: 8626939350
- Compiled artifact digest: sha256:b37940416081a311d0da5eb07f81b747c021f733fba138dc877fbef261f044e9

Final hashes:
- DLL: 421fbc6451ec2833454621e57305ae1acfaac07690baf316195e96ec9fea4bc0
- PDB: 7bd319fd139857753b79e5c99fee2d115f4d108a64347def51f2bfd09660c9e5
- Behavior source: 69a0cba342a232e7771a5fa46d2ee96ca66d7f8ec73c0380f07afbc008330954
- Damage bridge source: 3cb8394d802a75cb23ffaa3ba8cde723462dca09118988dc8b6d0e73ee9b95f9
- Patch: 26d5ed256a07e64cfbef1444fe82c839d302f38de37c578ffd5ab790f5cf2b9f
- CLEAN archive: 1d55434058f80c830e878389c0921fba8c70494f25b7d446757e00edd88997c9
- FULL SOURCE archive: 9f0f67c2befbba8af631c82a977836c48fd10fe2609fef24fba7547ca3b4dc5c

Closed without merge after artifact retrieval and verified clean/full packaging.