### PR TITLE
Fix runtime manifest line-ending parity check

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,10 +37,15 @@ jobs:
 
           $main = (Get-FileHash ".\bin\Win64_Shipping_Client\ExtremeRagdoll.dll" -Algorithm SHA256).Hash.ToLowerInvariant()
           $helper = (Get-FileHash ".\bin\Win64_Shipping_Client\ExtremeRagdoll.ClothSync.dll" -Algorithm SHA256).Hash.ToLowerInvariant()
-          @(
+          $manifest = @(
             "$main  bin/Win64_Shipping_Client/ExtremeRagdoll.dll"
             "$helper  bin/Win64_Shipping_Client/ExtremeRagdoll.ClothSync.dll"
-          ) | Set-Content ".\RUNTIME_SHA256.txt" -Encoding ascii
+          )
+          $manifestPath = Join-Path $env:GITHUB_WORKSPACE "RUNTIME_SHA256.txt"
+          [System.IO.File]::WriteAllText(
+            $manifestPath,
+            ($manifest -join "`n") + "`n",
+            [System.Text.Encoding]::ASCII)
 
       - name: Update PR runtime binaries
         if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository


### PR DESCRIPTION
## Root cause

The Windows workflow rewrote `RUNTIME_SHA256.txt` with CRLF via `Set-Content`, while `.gitattributes` requires LF for `*.txt`. The default-branch verification therefore saw a dirty worktree even though the DLLs and manifest values matched the current source.

## Fix

Write the runtime manifest explicitly as ASCII with LF separators and a final LF. No source, runtime binary, packaging, or gameplay behaviour changes.

## Validation

The PR workflow must rebuild both assemblies and report that the committed runtime already matches the current source. After merge, the `master` workflow must pass the default-branch parity check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved build-time generation of the runtime checksum file.
  * Preserved existing runtime files and paths while ensuring consistent formatting and encoding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->