### PR TITLE
Prepare corrected Extreme Ragdoll v1.3.11 release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,11 +79,11 @@ jobs:
           Copy-Item ".\SubModule.xml" $stage
           Copy-Item ".\ModuleData" $stage -Recurse
           Copy-Item ".\bin" $stage -Recurse
-          Compress-Archive -Path $stage -DestinationPath ".\ExtremeRagdoll-v1.3.10.zip" -Force
+          Compress-Archive -Path $stage -DestinationPath ".\ExtremeRagdoll-v1.3.11.zip" -Force
 
       - name: Upload module artifact
         uses: actions/upload-artifact@v4
         with:
-          name: ExtremeRagdoll-v1.3.10
-          path: ExtremeRagdoll-v1.3.10.zip
+          name: ExtremeRagdoll-v1.3.11
+          path: ExtremeRagdoll-v1.3.11.zip
           if-no-files-found: error

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## v1.3.11
+
+- Rebuilt and republished the runtime DLLs from the maintained source after the earlier Nexus v1.3.10 package was found to contain stale binaries.
+- Synchronized the module version, repository metadata, compiled runtime verification, package naming, and release assets.
+- Retained the complete v1.3.10 Dismemberment Plus compatibility safeguards and Simplified Chinese localization.
+- Added no further gameplay changes beyond the maintained v1.3.10 source.
+
 ## v1.3.10
 
 - Added automatic Dismemberment Plus compatibility safeguards.

--- a/README.md
+++ b/README.md
@@ -2,12 +2,12 @@
 
 Extreme Ragdoll is a Mount & Blade II: Bannerlord single-player mod that amplifies directional death physics while preserving Bannerlord's normal corpse and mission lifecycle.
 
-Current repository version: **v1.3.10**  
+Current repository version: **v1.3.11**  
 Supported Bannerlord range: **v1.3.15–v1.4.7**
 
 ## Repository layout
 
-- `Source/` — current v1.3.10 C# source and the minimal deterministic build toolchain.
+- `Source/` — current v1.3.11 C# source and the minimal deterministic build toolchain.
 - `bin/Win64_Shipping_Client/` — compiled runtime DLLs loaded by Bannerlord.
 - `ModuleData/Languages/` — English and Simplified Chinese MCM localization.
 - `SubModule.xml` — Bannerlord module manifest.
@@ -17,12 +17,12 @@ Historical patch chains, intermediate binaries, reconstruction payloads, old bui
 
 ## Installation
 
-1. Download or clone the repository.
-2. Copy the repository folder into Bannerlord's `Modules` directory and name it `ExtremeRagdoll`.
+1. Download the installable ZIP from the latest GitHub release.
+2. Extract the included `ExtremeRagdoll` folder into Bannerlord's `Modules` directory.
 3. Ensure Harmony and Mod Configuration Menu v5 are installed.
 4. Enable **Extreme Ragdoll** in the Bannerlord launcher or BLSE.
 
-The runtime module requires only these repository paths:
+The runtime module requires only these paths:
 
 ```text
 ExtremeRagdoll/
@@ -61,13 +61,15 @@ Build output is written to `Source/Build/out/bin`. The reference stubs are compi
 
 Pull-request CI rebuilds the current source and updates the checked-in runtime DLLs when their bytes differ. The default branch then rebuilds and fails if the committed binaries or `RUNTIME_SHA256.txt` do not match the source build.
 
-## v1.3.10 scope
+## v1.3.11 scope
 
+- Corrective distribution release for the maintained Dismemberment Plus compatibility source.
+- Rebuilds and republishes the runtime DLLs under a new version after the earlier Nexus v1.3.10 package was found to contain stale binaries.
 - Automatically detects Dismemberment Plus.
 - Avoids force-finalizing active corpses while Dismemberment Plus may be rebuilding body or armour meshes.
 - Disables Extreme Ragdoll's nonlethal push and knockdown injection only while Dismemberment Plus is loaded.
 - Retains lethal death-launch physics with Dismemberment Plus.
-- Adds complete Simplified Chinese MCM localization.
-- Preserves v1.3.9 behavior when Dismemberment Plus is absent.
+- Includes complete Simplified Chinese MCM localization.
+- Preserves normal v1.3.9 behavior when Dismemberment Plus is absent.
 
-Runtime validation in a real Bannerlord + Dismemberment Plus + custom-armour battle remains required for the native access-violation interaction.
+v1.3.11 introduces no additional gameplay changes beyond the maintained v1.3.10 source. Runtime validation in a real Bannerlord + Dismemberment Plus + custom-armour battle remains required for the native access-violation interaction.

--- a/Source/BUILDING.md
+++ b/Source/BUILDING.md
@@ -1,4 +1,4 @@
-# Building Extreme Ragdoll v1.3.10
+# Building Extreme Ragdoll v1.3.11
 
 ## Canonical inputs
 

--- a/SubModule.xml
+++ b/SubModule.xml
@@ -2,7 +2,7 @@
 <Module>
   <Name value="Extreme Ragdoll" />
   <Id value="ExtremeRagdoll" />
-  <Version value="v1.3.10" />
+  <Version value="v1.3.11" />
   <DefaultModule value="false" />
   <SingleplayerModule value="true" />
   <MultiplayerModule value="false" />


### PR DESCRIPTION
## Version bump

- Updates `SubModule.xml` to `v1.3.11`.
- Updates repository, build, and changelog metadata.
- Renames CI module artifacts to v1.3.11.

## Release purpose

v1.3.11 is the corrective distribution release for Nexus users. The earlier Nexus v1.3.10 archive contained stale compiled binaries that did not match the maintained v1.3.10 compatibility source. This version gives the synchronized runtime a distinct module and release version.

## Runtime scope

No additional gameplay changes are introduced beyond the maintained v1.3.10 source. CI must rebuild and validate both assemblies, verify source/runtime parity, and package the v1.3.11 module before merge.