### PR TITLE
Fix Simplified Chinese MCM localization loading

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,7 @@ jobs:
         with:
           ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Install .NET Core SDK 3.1
         uses: actions/setup-dotnet@v4
@@ -50,6 +51,8 @@ jobs:
       - name: Update PR runtime binaries
         if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
         shell: pwsh
+        env:
+          GH_PUSH_TOKEN: ${{ github.token }}
         run: |
           if (-not (git status --porcelain -- bin/Win64_Shipping_Client RUNTIME_SHA256.txt)) {
             Write-Host "Runtime binaries already match the current source."
@@ -60,7 +63,7 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add -- bin/Win64_Shipping_Client RUNTIME_SHA256.txt
           git commit -m "Build current runtime binaries"
-          git push origin "HEAD:${{ github.event.pull_request.head.ref }}"
+          git push "https://x-access-token:$env:GH_PUSH_TOKEN@github.com/${{ github.repository }}.git" "HEAD:${{ github.event.pull_request.head.ref }}"
 
       - name: Verify committed runtime on default branch
         if: github.event_name != 'pull_request'
@@ -71,6 +74,61 @@ jobs:
             throw "Committed runtime binaries do not match the current source build."
           }
 
+      - name: Validate module and localization data
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+
+          [xml]$module = Get-Content '.\SubModule.xml' -Raw
+          if ($module.Module.Version.value -ne 'v1.3.14') {
+            throw "Unexpected module version: $($module.Module.Version.value)"
+          }
+
+          [xml]$languageData = Get-Content '.\ModuleData\Languages\CNs\language_data.xml' -Raw
+          $registeredFiles = @($languageData.LanguageData.LanguageFile | ForEach-Object { $_.xml_path })
+          if ($registeredFiles.Count -ne 1 -or $registeredFiles[0] -ne 'CNs/std_module_strings_xml.xml') {
+            throw "Unexpected Simplified Chinese language registration: $($registeredFiles -join ', ')"
+          }
+
+          [xml]$english = Get-Content '.\ModuleData\Languages\std_module_strings_xml.xml' -Raw
+          [xml]$chinese = Get-Content '.\ModuleData\Languages\CNs\std_module_strings_xml.xml' -Raw
+          foreach ($table in @($english, $chinese)) {
+            $root = $table.DocumentElement
+            if ($root.LocalName -ne 'base' -or $root.GetAttribute('type') -ne 'string') {
+              throw 'Localization string table must use a <base type="string"> root.'
+            }
+            if ($root.GetNamespaceOfPrefix('xsi') -ne 'http://www.w3.org/2001/XMLSchema-instance' -or
+                $root.GetNamespaceOfPrefix('xsd') -ne 'http://www.w3.org/2001/XMLSchema') {
+              throw 'Localization string table is missing the standard XML schema namespace declarations.'
+            }
+          }
+
+          $englishLanguage = [string]$english.base.tags.tag.language
+          $chineseLanguage = [string]$chinese.base.tags.tag.language
+          if ($englishLanguage -ne 'English') { throw "Unexpected base language tag: $englishLanguage" }
+          if ($chineseLanguage -ne '简体中文') { throw "Unexpected Chinese language tag: $chineseLanguage" }
+
+          $englishNodes = @($english.base.strings.string)
+          $chineseNodes = @($chinese.base.strings.string)
+          $englishIds = @($englishNodes | ForEach-Object { [string]$_.id })
+          $chineseIds = @($chineseNodes | ForEach-Object { [string]$_.id })
+          if (($englishIds | Sort-Object -Unique).Count -ne $englishIds.Count) { throw 'Duplicate English localization IDs.' }
+          if (($chineseIds | Sort-Object -Unique).Count -ne $chineseIds.Count) { throw 'Duplicate Chinese localization IDs.' }
+          if (($englishIds | Sort-Object) -join "`n" -ne ($chineseIds | Sort-Object) -join "`n") {
+            throw 'English and Simplified Chinese localization ID sets differ.'
+          }
+          if (@($englishNodes | Where-Object { [string]::IsNullOrWhiteSpace([string]$_.text) }).Count -gt 0 -or
+              @($chineseNodes | Where-Object { [string]::IsNullOrWhiteSpace([string]$_.text) }).Count -gt 0) {
+            throw 'Localization contains an empty translation value.'
+          }
+
+          $sourceText = Get-Content '.\Source\SafeSubModule.cs' -Raw
+          $referencedIds = @([regex]::Matches($sourceText, '\{=([A-Za-z0-9_]+)\}') | ForEach-Object { $_.Groups[1].Value } | Sort-Object -Unique)
+          $missingIds = @($referencedIds | Where-Object { $_ -notin $englishIds })
+          if ($missingIds.Count -gt 0) {
+            throw "Source references missing localization IDs: $($missingIds -join ', ')"
+          }
+
       - name: Package module artifact
         shell: pwsh
         run: |
@@ -79,11 +137,11 @@ jobs:
           Copy-Item ".\SubModule.xml" $stage
           Copy-Item ".\ModuleData" $stage -Recurse
           Copy-Item ".\bin" $stage -Recurse
-          Compress-Archive -Path $stage -DestinationPath ".\ExtremeRagdoll-v1.3.13.zip" -Force
+          Compress-Archive -Path $stage -DestinationPath ".\ExtremeRagdoll-v1.3.14.zip" -Force
 
       - name: Upload module artifact
         uses: actions/upload-artifact@v4
         with:
-          name: ExtremeRagdoll-v1.3.13
-          path: ExtremeRagdoll-v1.3.13.zip
+          name: ExtremeRagdoll-v1.3.14
+          path: ExtremeRagdoll-v1.3.14.zip
           if-no-files-found: error

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,7 +63,7 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add -- bin/Win64_Shipping_Client RUNTIME_SHA256.txt
           git commit -m "Build current runtime binaries"
-          git push "https://x-access-token:$env:GH_PUSH_TOKEN@github.com/${{ github.repository }}.git" "HEAD:${{ github.event.pull_request.head.ref }}"
+          git push "https://x-access-token:${env:GH_PUSH_TOKEN}@github.com/${{ github.repository }}.git" "HEAD:${{ github.event.pull_request.head.ref }}"
 
       - name: Verify committed runtime on default branch
         if: github.event_name != 'pull_request'
@@ -114,7 +114,9 @@ jobs:
           $chineseIds = @($chineseNodes | ForEach-Object { [string]$_.id })
           if (($englishIds | Sort-Object -Unique).Count -ne $englishIds.Count) { throw 'Duplicate English localization IDs.' }
           if (($chineseIds | Sort-Object -Unique).Count -ne $chineseIds.Count) { throw 'Duplicate Chinese localization IDs.' }
-          if (($englishIds | Sort-Object) -join "`n" -ne ($chineseIds | Sort-Object) -join "`n") {
+          $englishKeySet = ($englishIds | Sort-Object) -join "`n"
+          $chineseKeySet = ($chineseIds | Sort-Object) -join "`n"
+          if ($englishKeySet -ne $chineseKeySet) {
             throw 'English and Simplified Chinese localization ID sets differ.'
           }
           if (@($englishNodes | Where-Object { [string]::IsNullOrWhiteSpace([string]$_.text) }).Count -gt 0 -or

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## v1.3.14
+
+- Corrected both localization string files to Bannerlord's required `type="string"` XML format.
+- Added the standard XML namespace declaration used by working Bannerlord module localization files.
+- Retained the corrected Simplified Chinese language manifest and complete translation key set.
+- Added package validation that rejects malformed base or Simplified Chinese string-table roots before release.
+- No gameplay or physics behavior changed.
+
 ## v1.3.13
 
 - Replaced the v1.3.12 direction guards with an authoritative-source direction pipeline.

--- a/ModuleData/Languages/CNs/std_module_strings_xml.xml
+++ b/ModuleData/Languages/CNs/std_module_strings_xml.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<base xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../Languages.xsd">
+<base xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" type="string">
   <tags>
     <tag language="简体中文" />
   </tags>

--- a/ModuleData/Languages/std_module_strings_xml.xml
+++ b/ModuleData/Languages/std_module_strings_xml.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<base xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../Languages.xsd">
+<base xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" type="string">
   <tags>
     <tag language="English" />
   </tags>

--- a/README.md
+++ b/README.md
@@ -2,12 +2,12 @@
 
 Extreme Ragdoll is a Mount & Blade II: Bannerlord single-player mod that amplifies directional death physics while preserving Bannerlord's normal corpse and mission lifecycle.
 
-Current repository version: **v1.3.13**  
+Current repository version: **v1.3.14**  
 Supported Bannerlord range: **v1.3.15–v1.4.7**
 
 ## Repository layout
 
-- `Source/` — current v1.3.13 C# source and the minimal deterministic build toolchain.
+- `Source/` — current v1.3.14 C# source and the minimal deterministic build toolchain.
 - `bin/Win64_Shipping_Client/` — compiled runtime DLLs loaded by Bannerlord.
 - `ModuleData/Languages/` — English and Simplified Chinese MCM localization.
 - `SubModule.xml` — Bannerlord module manifest.
@@ -61,13 +61,11 @@ Build output is written to `Source/Build/out/bin`. The reference stubs are compi
 
 Pull-request CI rebuilds the current source and updates the checked-in runtime DLLs when their bytes differ. The default branch then rebuilds and fails if the committed binaries or `RUNTIME_SHA256.txt` do not match the source build.
 
-## v1.3.13 scope
+## v1.3.14 scope
 
-- Makes the captured hit direction authoritative for normal death launches.
-- Uses `KillingBlow.RagdollImpulseAmount` only as a last-resort fallback when neither impact data nor attacker geometry exists.
-- Applies victim momentum exactly once during first-pulse force construction and removes only the opposing longitudinal component.
-- Corrects the Simplified Chinese language manifest path and metadata so Bannerlord loads the existing translation file.
-- Resolves the MCM display name through Bannerlord `TextObject` instead of exposing the raw localization token.
-- Retains force magnitude, pulse delivery, hit-bone routing, mount-collision scaling, corpse lifecycle behavior, and Dismemberment Plus safeguards.
+- Corrects the English and Simplified Chinese string tables to Bannerlord's required `type="string"` localization XML shape.
+- Retains the corrected `CNs/language_data.xml` registration path and complete Chinese translation set.
+- Adds package checks for the string-table root type, language tags, registered file path, and matching localization IDs.
+- Makes no gameplay, force, ragdoll, corpse lifecycle, compatibility, or performance changes.
 
-Runtime validation inside Bannerlord remains required for native physics and MCM rendering behavior that cannot be executed in GitHub Actions.
+Runtime validation inside Bannerlord remains required for MCM rendering behavior that cannot be executed in GitHub Actions.

--- a/SubModule.xml
+++ b/SubModule.xml
@@ -2,7 +2,7 @@
 <Module>
   <Name value="Extreme Ragdoll" />
   <Id value="ExtremeRagdoll" />
-  <Version value="v1.3.13" />
+  <Version value="v1.3.14" />
   <DefaultModule value="false" />
   <SingleplayerModule value="true" />
   <MultiplayerModule value="false" />


### PR DESCRIPTION
## Symptom

Bannerlord and MCM render the game UI in Simplified Chinese, while every Extreme Ragdoll MCM group and setting still renders its English fallback text.

## Root cause

The v1.3.13 manifest correction made Bannerlord locate the Chinese file, and both Extreme Ragdoll string tables still used a generic `<base>` root without Bannerlord's required `type="string"` localization-table marker. Working Bannerlord module string tables use `<base ... type="string">`; without that marker, the files are not registered as string resources, so `TextObject` falls back to the English text embedded in the MCM attributes.

## Fix

- Change both the English and Simplified Chinese string-table roots to Bannerlord's standard `type="string"` XML shape.
- Add the standard `xsi` and `xsd` namespace declarations used by working module localization files.
- Retain the corrected `CNs/language_data.xml` registration path and complete translation key set.
- Add CI checks for the module version, registered Chinese path, string-table root type, language tags, duplicate IDs, empty values, matching English/Chinese IDs, and source-referenced localization keys.
- Package the module as v1.3.14.

## Scope

No runtime DLL source, gameplay physics, force calculation, ragdoll lifecycle, Dismemberment Plus compatibility, or campaign performance behavior is changed.

## Validation

- Deterministic source build passed.
- Assembly validation passed.
- Runtime DLL parity passed; DLL hashes are unchanged from v1.3.13.
- Localization structure, registration, key parity, non-empty values, and source references passed.
- The packaged v1.3.14 artifact was extracted and independently inspected for module layout, version, language manifest, string-table roots, and DLL hashes.

Native in-game MCM rendering remains the final runtime validation step.