### PR TITLE
Fix v1.3.16 release workflow validation

### DIFF
--- a/.github/workflows/release-current.yml
+++ b/.github/workflows/release-current.yml
@@ -98,7 +98,7 @@ jobs:
             'RequireGetter(propertyVmType, "Name")',
             'RequireGetter(groupVmType, "GroupNameDisplay")',
             'RequireGetter(settingsVmType, "DisplayName")',
-            'RequireGetter(settingsEntryVmType, "DisplayName")',
+            'RequireGetter(entryVmType, "DisplayName")',
             'RequireGetter(modOptionsVmType, "SelectedDisplayName")',
             'ExtremeRagdoll.Localization.log',
             'OnBeforeInitialModuleScreenSetAsRoot',


### PR DESCRIPTION
## Failure

The v1.3.16 publication workflow correctly checked the immutable implementation commit, but one source-marker assertion used the nonexistent local name `settingsEntryVmType`. The implementation uses `entryVmType`, so publication stopped before creating the tag or release.

## Correction

- Match the exact maintained source marker: `RequireGetter(entryVmType, "DisplayName")`.
- Keep the immutable target, package hash binding, release notes, asset verification, and all other checks unchanged.

The PR remains draft until CI passes.